### PR TITLE
feat: auth api 연결 및 코드 구조 리팩토링

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-/.env
+.env
 backend/.env
 
 node_modules/

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,1 @@
+REACT_APP_API_HOST=http://localhost:4000

--- a/frontend/src/components/Auth/Auth.css
+++ b/frontend/src/components/Auth/Auth.css
@@ -63,7 +63,7 @@
   left: 0;
   right: 0;
   height: 3px;
-  background: linear-gradient(90deg, #00CCFF 0%, var(--accent-primary) 100%);
+  background: linear-gradient(90deg, var(--accent-blue) 0%, var(--accent-primary) 100%);
   border-top-left-radius: var(--radius-lg);
   border-top-right-radius: var(--radius-lg);
 }
@@ -124,6 +124,13 @@
 .btn-neon:hover {
   transform: translateY(-2px);
   box-shadow: 0 8px 25px rgba(0, 255, 102, 0.5);
+}
+
+.btn-neon:disabled {
+  cursor: not-allowed;
+  opacity: 0.7;
+  transform: none;
+  box-shadow: none;
 }
 
 /* Divider */
@@ -188,6 +195,20 @@
 .auth-link:hover {
   color: #00CC52;
   text-decoration: underline;
+}
+
+.auth-error {
+  margin: 0 0 12px;
+  color: var(--color-error);
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+.auth-success {
+  margin: 0 0 16px;
+  color: var(--accent-primary);
+  font-size: 13px;
+  line-height: 1.4;
 }
 
 /* Terminal Icon SVG specific styles */

--- a/frontend/src/components/Auth/Login.js
+++ b/frontend/src/components/Auth/Login.js
@@ -1,15 +1,18 @@
-import React from 'react';
-import { Link, useNavigate } from 'react-router-dom';
-import './Auth.css';
+import React, { useState } from "react";
+import { Link, useLocation, useNavigate } from "react-router-dom";
+import { login as loginApi } from "../../lib/auth";
+import { useAuth } from "../../contexts/AuthContext";
+import { PATHS } from "../../constants/path";
+import "./Auth.css";
 
 const TerminalIcon = () => (
-  <svg 
-    className="terminal-icon" 
-    viewBox="0 0 24 24" 
-    fill="none" 
-    stroke="currentColor" 
-    strokeWidth="2" 
-    strokeLinecap="round" 
+  <svg
+    className="terminal-icon"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
     strokeLinejoin="round"
   >
     <polyline points="4 17 10 11 4 5"></polyline>
@@ -18,50 +21,103 @@ const TerminalIcon = () => (
 );
 
 const GoogleIcon = () => (
-  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-    <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z" fill="#4285F4"/>
-    <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853"/>
-    <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" fill="#FBBC05"/>
-    <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335"/>
+  <svg
+    width="18"
+    height="18"
+    viewBox="0 0 24 24"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
+      fill="#4285F4"
+    />
+    <path
+      d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+      fill="#34A853"
+    />
+    <path
+      d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+      fill="#FBBC05"
+    />
+    <path
+      d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+      fill="#EA4335"
+    />
   </svg>
 );
 
-const Login = ({ onLoginSuccess }) => {
+const Login = () => {
   const navigate = useNavigate();
+  const location = useLocation();
+  const { login } = useAuth();
+  const successMessage = location.state?.successMessage || "";
+  const registeredEmail = location.state?.registeredEmail || "";
 
-  const handleLogin = (e) => {
+  const [email, setEmail] = useState(registeredEmail);
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  const handleLogin = async (e) => {
     e.preventDefault();
-    if (onLoginSuccess) {
-      onLoginSuccess();
-      return;
-    }
+    setError("");
+    setLoading(true);
 
-    navigate('/');
+    try {
+      const data = await loginApi({ email, password });
+
+      login({
+        nickname: data.nickname,
+        profileImageUrl: data.profileImageUrl,
+        accessToken: data.access_token,
+        refreshToken: data.refresh_token,
+      });
+
+      navigate(PATHS.explore, { replace: true });
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
   };
 
   return (
     <div className="auth-container">
-      <button 
-        onClick={() => navigate(-1)} 
+      <button
+        onClick={() => navigate(PATHS.onboarding)}
         style={{
-          position: 'absolute',
-          top: '32px',
-          left: '32px',
-          background: 'none',
-          border: 'none',
-          color: 'var(--text-secondary)',
-          cursor: 'pointer',
-          display: 'flex',
-          alignItems: 'center',
-          gap: '8px',
-          fontSize: '14px',
+          position: "absolute",
+          top: "32px",
+          left: "32px",
+          background: "none",
+          border: "none",
+          color: "var(--text-secondary)",
+          cursor: "pointer",
+          display: "flex",
+          alignItems: "center",
+          gap: "8px",
+          fontSize: "14px",
           fontWeight: 600,
-          transition: 'color 0.2s',
+          transition: "color 0.2s",
         }}
-        onMouseOver={(e) => e.currentTarget.style.color = 'var(--text-primary)'}
-        onMouseOut={(e) => e.currentTarget.style.color = 'var(--text-secondary)'}
+        onMouseOver={(e) =>
+          (e.currentTarget.style.color = "var(--text-primary)")
+        }
+        onMouseOut={(e) =>
+          (e.currentTarget.style.color = "var(--text-secondary)")
+        }
       >
-        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <svg
+          width="20"
+          height="20"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
           <line x1="19" y1="12" x2="5" y2="12"></line>
           <polyline points="12 19 5 12 12 5"></polyline>
         </svg>
@@ -78,16 +134,20 @@ const Login = ({ onLoginSuccess }) => {
 
       <div className="auth-card">
         <form onSubmit={handleLogin}>
+          {successMessage && <p className="auth-success">{successMessage}</p>}
+
           <div className="form-group">
             <label className="form-label" htmlFor="email-or-phone">
               이메일 또는 전화번호
             </label>
-            <input 
+            <input
               className="form-input"
-              id="email-or-phone" 
-              type="text" 
+              id="email-or-phone"
+              type="text"
               placeholder="예: nathan@substratum.io"
               autoComplete="username"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
               required
             />
           </div>
@@ -96,18 +156,22 @@ const Login = ({ onLoginSuccess }) => {
             <label className="form-label" htmlFor="password">
               비밀번호
             </label>
-            <input 
+            <input
               className="form-input"
-              id="password" 
-              type="password" 
+              id="password"
+              type="password"
               placeholder="••••••••"
               autoComplete="current-password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
               required
             />
           </div>
 
-          <button type="submit" className="btn-neon">
-            로그인
+          {error && <p className="auth-error">{error}</p>}
+
+          <button type="submit" className="btn-neon" disabled={loading}>
+            {loading ? "로그인 중..." : "로그인"}
           </button>
         </form>
 
@@ -121,7 +185,10 @@ const Login = ({ onLoginSuccess }) => {
       </div>
 
       <div className="auth-footer">
-        아직 계정이 없으신가요? <Link to="/register" className="auth-link">회원가입</Link>
+        아직 계정이 없으신가요?{" "}
+        <Link to={PATHS.register} className="auth-link">
+          회원가입
+        </Link>
       </div>
     </div>
   );

--- a/frontend/src/components/Auth/Register.js
+++ b/frontend/src/components/Auth/Register.js
@@ -1,15 +1,17 @@
-import React from 'react';
-import { Link, useNavigate } from 'react-router-dom';
-import './Auth.css';
+import React, { useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import { register as registerApi } from "../../lib/auth";
+import { PATHS } from "../../constants/path";
+import "./Auth.css";
 
 const TerminalIcon = () => (
-  <svg 
-    className="terminal-icon" 
-    viewBox="0 0 24 24" 
-    fill="none" 
-    stroke="currentColor" 
-    strokeWidth="2" 
-    strokeLinecap="round" 
+  <svg
+    className="terminal-icon"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
     strokeLinejoin="round"
   >
     <polyline points="4 17 10 11 4 5"></polyline>
@@ -17,42 +19,77 @@ const TerminalIcon = () => (
   </svg>
 );
 
-const Register = ({ onRegisterSuccess }) => {
+const Register = () => {
   const navigate = useNavigate();
 
-  const handleRegister = (e) => {
-    e.preventDefault();
-    if (onRegisterSuccess) {
-      onRegisterSuccess();
-      return;
-    }
+  const [email, setEmail] = useState("");
+  const [nickname, setNickname] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(false);
 
-    navigate('/login');
+  const handleRegister = async (e) => {
+    e.preventDefault();
+    setError("");
+    setLoading(true);
+
+    try {
+      await registerApi({
+        email,
+        password,
+        nickname,
+      });
+
+      navigate(PATHS.login, {
+        replace: true,
+        state: {
+          registeredEmail: email,
+          successMessage: "회원가입이 완료되었습니다. 로그인해 주세요.",
+        },
+      });
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
   };
 
   return (
     <div className="auth-container">
-      <button 
-        onClick={() => navigate(-1)} 
+      <button
+        onClick={() => navigate(PATHS.onboarding)}
         style={{
-          position: 'absolute',
-          top: '32px',
-          left: '32px',
-          background: 'none',
-          border: 'none',
-          color: 'var(--text-secondary)',
-          cursor: 'pointer',
-          display: 'flex',
-          alignItems: 'center',
-          gap: '8px',
-          fontSize: '14px',
+          position: "absolute",
+          top: "32px",
+          left: "32px",
+          background: "none",
+          border: "none",
+          color: "var(--text-secondary)",
+          cursor: "pointer",
+          display: "flex",
+          alignItems: "center",
+          gap: "8px",
+          fontSize: "14px",
           fontWeight: 600,
-          transition: 'color 0.2s',
+          transition: "color 0.2s",
         }}
-        onMouseOver={(e) => e.currentTarget.style.color = 'var(--text-primary)'}
-        onMouseOut={(e) => e.currentTarget.style.color = 'var(--text-secondary)'}
+        onMouseOver={(e) =>
+          (e.currentTarget.style.color = "var(--text-primary)")
+        }
+        onMouseOut={(e) =>
+          (e.currentTarget.style.color = "var(--text-secondary)")
+        }
       >
-        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <svg
+          width="20"
+          height="20"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
           <line x1="19" y1="12" x2="5" y2="12"></line>
           <polyline points="12 19 5 12 12 5"></polyline>
         </svg>
@@ -73,24 +110,28 @@ const Register = ({ onRegisterSuccess }) => {
             <label className="form-label" htmlFor="email">
               이메일 주소
             </label>
-            <input 
+            <input
               className="form-input"
-              id="email" 
-              type="email" 
+              id="email"
+              type="email"
               placeholder="name@example.com"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
               required
             />
           </div>
 
           <div className="form-group">
-            <label className="form-label" htmlFor="username">
-              사용자 이름
+            <label className="form-label" htmlFor="nickname">
+              닉네임
             </label>
-            <input 
+            <input
               className="form-input"
-              id="username" 
-              type="text" 
-              placeholder="neon_nomad_88"
+              id="nickname"
+              type="text"
+              placeholder="테스터"
+              value={nickname}
+              onChange={(e) => setNickname(e.target.value)}
               required
             />
           </div>
@@ -99,23 +140,30 @@ const Register = ({ onRegisterSuccess }) => {
             <label className="form-label" htmlFor="password">
               비밀번호
             </label>
-            <input 
+            <input
               className="form-input"
-              id="password" 
-              type="password" 
+              id="password"
+              type="password"
               placeholder="••••••••"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
               required
             />
           </div>
 
-          <button type="submit" className="btn-neon">
-            계속하기
+          {error && <p className="auth-error">{error}</p>}
+
+          <button type="submit" className="btn-neon" disabled={loading}>
+            {loading ? "가입 중..." : "계속하기"}
           </button>
         </form>
       </div>
 
       <div className="auth-footer">
-        이미 계정이 있으신가요? <Link to="/login" className="auth-link">로그인</Link>
+        이미 계정이 있으신가요?{" "}
+        <Link to={PATHS.login} className="auth-link">
+          로그인
+        </Link>
       </div>
     </div>
   );

--- a/frontend/src/components/Chat/ChatLayout.js
+++ b/frontend/src/components/Chat/ChatLayout.js
@@ -1,6 +1,8 @@
 // ChatLayout.js
 import React, { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
+import { PATHS } from '../../constants/path';
+import { getRooms } from '../../lib/rooms';
 import './ChatLayout.css';
 import ServerSidebar from '../layout/ServerSidebar';
 import SidebarLeft from './SidebarLeft';
@@ -21,8 +23,7 @@ const ChatLayout = () => {
 
   useEffect(() => {
     setLoading(true);
-    fetch(`http://localhost:4000/dev/rooms`) // 전체를 가져와서 찾거나, 상세 API가 있다면 그걸 사용
-      .then(res => res.json())
+    getRooms()
       .then(data => {
         // 배열 중에서 현재 URL의 roomId와 일치하는 방을 찾습니다.
         const foundRoom = data.find(r => r.roomId === roomId);
@@ -58,7 +59,7 @@ const ChatLayout = () => {
     return (
       <div style={{ padding: '20px', color: 'white' }}>
         <h3>방을 찾을 수 없습니다. (ID: {roomId})</h3>
-        <button onClick={() => navigate('/explore')}>목록으로 돌아가기</button>
+        <button onClick={() => navigate(PATHS.explore)}>목록으로 돌아가기</button>
       </div>
     );
   }

--- a/frontend/src/components/NotFound/NotFound.js
+++ b/frontend/src/components/NotFound/NotFound.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
+import { PATHS } from '../../constants/path';
 import './NotFound.css';
 
 const NotFound = () => {
@@ -13,7 +14,7 @@ const NotFound = () => {
         <p className="error-description">
           요청하신 페이지가 존재하지 않거나 이동되었을 수 있습니다.
         </p>
-        <button className="go-home-btn" onClick={() => navigate('/')}>
+        <button className="go-home-btn" onClick={() => navigate(PATHS.home)}>
           홈으로 돌아가기
         </button>
       </div>

--- a/frontend/src/components/Onboarding/Onboarding.js
+++ b/frontend/src/components/Onboarding/Onboarding.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { PATHS } from '../../constants/path';
 import './Onboarding.css';
 
 const slides = [
@@ -81,7 +82,7 @@ const Onboarding = ({ onLogin, onRegister }) => {
       return;
     }
 
-    navigate('/login');
+    navigate(PATHS.login);
   };
 
   const nextSlide = useCallback(() => {

--- a/frontend/src/components/Rooms/CreateRoomModal.js
+++ b/frontend/src/components/Rooms/CreateRoomModal.js
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { createRoom } from '../../lib/rooms';
 import './CreateRoomModal.css';
 
 const CreateRoomModal = ({ onClose }) => {
@@ -22,34 +23,17 @@ const CreateRoomModal = ({ onClose }) => {
     console.log("🚀 [STEP 1] 서버로 보낼 데이터(Payload):", newRoomData);
 
   try {
-    const response = await fetch('http://localhost:4000/dev/rooms', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify(newRoomData),
-    });
+    const result = await createRoom(newRoomData);
 
-    // [LOG 2] HTTP 상태 코드 확인 (200, 201 등)
-    console.log("📡 [STEP 2] 서버 응답 상태(Status):", response.status);
+    // [LOG 2] 서버가 실제로 DB에 저장하고 돌려준 데이터 확인
+    console.log("✅ [STEP 2] 서버가 저장한 최종 데이터(Result):", result);
 
-    if (response.ok) {
-      const result = await response.json();
-      
-      // [LOG 3] 서버가 실제로 DB에 저장하고 돌려준 데이터 확인
-      console.log("✅ [STEP 3] 서버가 저장한 최종 데이터(Result):", result);
-      
-      alert(`${groupName} 랩이 성공적으로 구축되었습니다!`);
-      onClose();
-      window.location.reload(); 
-    } else {
-      const errorData = await response.json();
-      console.error("❌ [ERROR] 서버 응답 에러:", errorData);
-      throw new Error('방 생성에 실패했습니다.');
-    }
+    alert(`${groupName} 랩이 성공적으로 구축되었습니다!`);
+    onClose();
+    window.location.reload(); 
   } catch (error) {
     console.error("🚨 [CRITICAL] 통신 에러 발생:", error);
-    alert("서버 통신 중 오류가 발생했습니다.");
+    alert(error.message || "서버 통신 중 오류가 발생했습니다.");
   }
 };
 

--- a/frontend/src/components/Rooms/ExploreRooms.js
+++ b/frontend/src/components/Rooms/ExploreRooms.js
@@ -1,5 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { getRoomPath } from '../../constants/path';
+import { getRooms } from '../../lib/rooms';
 import './ExploreRooms.css';
 import ServerSidebar from '../layout/ServerSidebar';
 import CreateRoomModal from './CreateRoomModal';
@@ -78,8 +80,7 @@ const ExploreRooms = () => {
   const [isModalOpen, setIsModalOpen] = useState(false);
 
   useEffect(() => {
-    fetch('http://localhost:4000/dev/rooms') // 전체를 가져와서 찾거나, 상세 API가 있다면 그걸 사용
-      .then(res => res.json())
+    getRooms()
       .then(data => setRooms(data))
       .catch(err => console.error("데이터 로드 실패!", err));
   }, []);
@@ -93,7 +94,7 @@ const ExploreRooms = () => {
 
   // 방 입장 시 해당 ID의 주소로 이동
   const handleJoinRoom = (roomId) => {
-    navigate(`/rooms/${roomId}`);
+    navigate(getRoomPath(roomId));
   };
 
   return (

--- a/frontend/src/components/layout/SharedLayout.js
+++ b/frontend/src/components/layout/SharedLayout.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import AuthActionButton from '../common/AuthActionButton';
+import { PATHS } from '../../constants/path';
 import './SharedLayout.css';
 
 const SharedLayout = ({ children, isLoggedIn, onLogout }) => {
@@ -8,11 +9,11 @@ const SharedLayout = ({ children, isLoggedIn, onLogout }) => {
   const navigate = useNavigate();
 
   // 로그인, 회원가입 페이지에서는 버튼 영역을 렌더링하지 않음
-  const isAuthPage = location.pathname === '/login' || location.pathname === '/register';
+  const isAuthPage = location.pathname === PATHS.login || location.pathname === PATHS.register;
 
-  const handleLoginClick = () => navigate('/login');
-  const handleRegisterClick = () => navigate('/register');
-  const handleLogoClick = () => navigate('/'); 
+  const handleLoginClick = () => navigate(PATHS.login);
+  const handleRegisterClick = () => navigate(PATHS.register);
+  const handleLogoClick = () => navigate(PATHS.home); 
 
   return (
     <div className="App shared-layout-container">

--- a/frontend/src/constants/endpoint.js
+++ b/frontend/src/constants/endpoint.js
@@ -1,0 +1,20 @@
+const API_HOST = process.env.REACT_APP_API_HOST || "http://localhost:4000";
+const API_STAGE = "/dev";
+
+export const API_BASE_URL = `${API_HOST}${API_STAGE}`;
+
+export const ENDPOINTS = {
+  auth: {
+    register: "/userRegister",
+    login: "/userLogin",
+    refresh: "/token/refresh",
+    logout: "/userLogout",
+  },
+  rooms: {
+    list: "/rooms",
+  },
+};
+
+export function createApiUrl(path) {
+  return `${API_BASE_URL}${path}`;
+}

--- a/frontend/src/constants/path.js
+++ b/frontend/src/constants/path.js
@@ -1,0 +1,12 @@
+export const PATHS = {
+  home: "/",
+  onboarding: "/onboarding",
+  login: "/login",
+  register: "/register",
+  explore: "/explore",
+  room: "/rooms/:roomId",
+};
+
+export function getRoomPath(roomId) {
+  return `/rooms/${roomId}`;
+}

--- a/frontend/src/contexts/AuthContext.js
+++ b/frontend/src/contexts/AuthContext.js
@@ -1,51 +1,88 @@
-import React, { createContext, useContext, useState } from 'react';
+import React, { createContext, useContext, useState } from "react";
 
 // 전역에서 사용할 Auth Context 생성
 const AuthContext = createContext();
 
+const ACCESS_TOKEN_KEY = "accessToken";
+const REFRESH_TOKEN_KEY = "refreshToken";
+const USER_KEY = "user";
+
 /**
  * 전역 인증 상태 제공자 컴포넌트
- * App 전체를 감싸서 로그인 정보를 공유합니다.
+ * App 전체를 감싸서 로그인 정보 공유
  */
 export const AuthProvider = ({ children }) => {
-  // 초기 상태: 로컬 스토리지에 로그인 정보가 있으면 가져옵니다 (테스트용)
-  const [isLoggedIn, setIsLoggedIn] = useState(() => {
-    return localStorage.getItem('isLoggedIn') === 'true';
-  });
-
+  const [accessToken, setAccessToken] = useState(() =>
+    localStorage.getItem(ACCESS_TOKEN_KEY),
+  );
+  const [refreshToken, setRefreshToken] = useState(() =>
+    localStorage.getItem(REFRESH_TOKEN_KEY),
+  );
   const [user, setUser] = useState(() => {
-    const savedUser = localStorage.getItem('user');
+    const savedUser = localStorage.getItem(USER_KEY);
     return savedUser ? JSON.parse(savedUser) : null;
   });
 
+  const isLoggedIn = Boolean(accessToken && refreshToken);
+
   // 로그인 처리 함수
-  const login = (userData = { name: 'StudyMaster_24', id: 'sm24' }) => {
-    setIsLoggedIn(true);
+  const login = ({
+    nickname,
+    profileImageUrl = null,
+    accessToken,
+    refreshToken,
+  }) => {
+    const userData = { nickname, profileImageUrl };
+
+    setAccessToken(accessToken);
+    setRefreshToken(refreshToken);
     setUser(userData);
-    localStorage.setItem('isLoggedIn', 'true');
-    localStorage.setItem('user', JSON.stringify(userData));
+
+    localStorage.setItem(ACCESS_TOKEN_KEY, accessToken);
+    localStorage.setItem(REFRESH_TOKEN_KEY, refreshToken);
+    localStorage.setItem(USER_KEY, JSON.stringify(userData));
+  };
+
+  // 액세스 토큰 업데이트 함수
+  const updateAccessToken = (newAccessToken) => {
+    setAccessToken(newAccessToken);
+    localStorage.setItem(ACCESS_TOKEN_KEY, newAccessToken);
   };
 
   // 로그아웃 처리 함수
   const logout = () => {
-    setIsLoggedIn(false);
+    setAccessToken(null);
+    setRefreshToken(null);
     setUser(null);
-    localStorage.removeItem('isLoggedIn');
-    localStorage.removeItem('user');
+
+    localStorage.removeItem(ACCESS_TOKEN_KEY);
+    localStorage.removeItem(REFRESH_TOKEN_KEY);
+    localStorage.removeItem(USER_KEY);
   };
 
   return (
-    <AuthContext.Provider value={{ isLoggedIn, user, login, logout }}>
+    <AuthContext.Provider
+      value={{
+        isLoggedIn,
+        user,
+        accessToken,
+        refreshToken,
+        login,
+        logout,
+        updateAccessToken,
+      }}
+    >
       {children}
     </AuthContext.Provider>
   );
 };
 
-// 다른 컴포넌트에서 쉽게 사용할 수 있도록 커스텀 훅 제공
 export const useAuth = () => {
   const context = useContext(AuthContext);
+
   if (!context) {
-    throw new Error('useAuth must be used within an AuthProvider');
+    throw new Error("useAuth must be used within an AuthProvider");
   }
+
   return context;
 };

--- a/frontend/src/lib/auth.js
+++ b/frontend/src/lib/auth.js
@@ -1,0 +1,38 @@
+import { ENDPOINTS } from "../constants/endpoint";
+import { request } from "./request";
+
+// 회원가입
+export function register(payload) {
+  return request(ENDPOINTS.auth.register, {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+}
+
+// 로그인
+export function login(payload) {
+  return request(ENDPOINTS.auth.login, {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+}
+
+// 토큰 재발급
+export function refreshAccessToken(refreshToken) {
+  return request(ENDPOINTS.auth.refresh, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${refreshToken}`,
+    },
+  });
+}
+
+// 로그아웃
+export function logout(refreshToken) {
+  return request(ENDPOINTS.auth.logout, {
+    method: "DELETE",
+    headers: {
+      Authorization: `Bearer ${refreshToken}`,
+    },
+  });
+}

--- a/frontend/src/lib/request.js
+++ b/frontend/src/lib/request.js
@@ -1,0 +1,37 @@
+import { createApiUrl } from "../constants/endpoint";
+
+export async function request(path, options = {}) {
+  const url = createApiUrl(path);
+
+  let response;
+
+  try {
+    response = await fetch(url, {
+      headers: {
+        "Content-Type": "application/json",
+        ...(options.headers || {}),
+      },
+      ...options,
+    });
+  } catch (error) {
+    throw new Error("서버에 연결할 수 없습니다. 백엔드가 실행 중인지 확인해 주세요.");
+  }
+
+  const contentType = response.headers.get("content-type") || "";
+  const isJsonResponse = contentType.includes("application/json");
+  const payload = isJsonResponse ? await response.json() : await response.text();
+
+  if (!response.ok) {
+    if (isJsonResponse) {
+      throw new Error(payload.detail || "요청에 실패했습니다.");
+    }
+
+    throw new Error("서버가 JSON이 아닌 응답을 반환했습니다. API 주소와 백엔드 실행 상태를 확인해 주세요.");
+  }
+
+  if (!isJsonResponse) {
+    throw new Error("서버 응답 형식이 올바르지 않습니다. API 주소를 확인해 주세요.");
+  }
+
+  return payload;
+}

--- a/frontend/src/lib/rooms.js
+++ b/frontend/src/lib/rooms.js
@@ -1,0 +1,15 @@
+import { ENDPOINTS } from "../constants/endpoint";
+import { request } from "./request";
+
+export function getRooms() {
+  return request(ENDPOINTS.rooms.list, {
+    method: "GET",
+  });
+}
+
+export function createRoom(payload) {
+  return request(ENDPOINTS.rooms.list, {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+}

--- a/frontend/src/pages/App.js
+++ b/frontend/src/pages/App.js
@@ -1,20 +1,19 @@
-import React, { useState } from 'react';
-import { Navigate, Route, Routes, useNavigate } from 'react-router-dom';
-import './App.css';
+import React from "react";
+import { Navigate, Route, Routes, useNavigate } from "react-router-dom";
+import "./App.css";
 
 // Context
-import { AuthProvider, useAuth } from '../contexts/AuthContext'; // ProtectedRoute를 위해 useAuth 추가
+import { AuthProvider, useAuth } from "../contexts/AuthContext";
 
 // Components
-import Onboarding from '../components/Onboarding/Onboarding';
-import Login from '../components/Auth/Login';
-import Register from '../components/Auth/Register';
-import ChatLayout from '../components/Chat/ChatLayout';
-import ExploreRooms from '../components/Rooms/ExploreRooms';
-import NotFound from '../components/NotFound/NotFound';
-import SharedLayout from '../components/layout/SharedLayout';
-
-const AUTH_STORAGE_KEY = 'smartstudy-authenticated';
+import Onboarding from "../components/Onboarding/Onboarding";
+import Login from "../components/Auth/Login";
+import Register from "../components/Auth/Register";
+import ChatLayout from "../components/Chat/ChatLayout";
+import ExploreRooms from "../components/Rooms/ExploreRooms";
+import NotFound from "../components/NotFound/NotFound";
+import SharedLayout from "../components/layout/SharedLayout";
+import { PATHS } from "../constants/path";
 
 /**
  * 로그인 여부에 따라 라우팅을 보호하는 컴포넌트
@@ -22,43 +21,45 @@ const AUTH_STORAGE_KEY = 'smartstudy-authenticated';
 const ProtectedRoute = ({ children }) => {
   const { isLoggedIn } = useAuth();
   if (!isLoggedIn) {
-    return <Navigate to="/login" replace />;
+    return <Navigate to={PATHS.login} replace />;
   }
   return children;
 };
 
 function AppRoutes() {
   const navigate = useNavigate();
-  const [isLoggedIn, setIsLoggedIn] = useState(() => sessionStorage.getItem(AUTH_STORAGE_KEY) === 'true');
+  const { isLoggedIn, refreshToken, logout } = useAuth();
 
-  const handleLogin = () => {
-    sessionStorage.setItem(AUTH_STORAGE_KEY, 'true');
-    setIsLoggedIn(true);
-    navigate('/explore', { replace: true });
-  };
-
-  const handleLogout = () => {
-    sessionStorage.removeItem(AUTH_STORAGE_KEY);
-    setIsLoggedIn(false);
-    navigate('/onboarding', { replace: true });
+  const handleLogout = async () => {
+    try {
+      if (refreshToken) {
+        const { logout: logoutApi } = await import("../lib/auth");
+        await logoutApi(refreshToken);
+      }
+    } catch (error) {
+      console.error("Logout failed:", error);
+    } finally {
+      logout();
+      navigate(PATHS.onboarding, { replace: true });
+    }
   };
 
   return (
     <SharedLayout isLoggedIn={isLoggedIn} onLogout={handleLogout}>
       <Routes>
         {/* 기존 라우팅 로직 유지 (이미 로그인한 사용자가 로그인/회원가입 페이지 접근 방지) */}
-        <Route path="/" element={isLoggedIn ? <Navigate to="/explore" replace /> : <Navigate to="/onboarding" replace />} />
-        <Route path="/onboarding" element={isLoggedIn ? <Navigate to="/explore" replace /> : <Onboarding />} />
+        <Route path={PATHS.home} element={isLoggedIn ? <Navigate to={PATHS.explore} replace /> : <Navigate to={PATHS.onboarding} replace />} />
+        <Route path={PATHS.onboarding} element={isLoggedIn ? <Navigate to={PATHS.explore} replace /> : <Onboarding />} />
         <Route
-          path="/login"
-          element={isLoggedIn ? <Navigate to="/explore" replace /> : <Login onLoginSuccess={handleLogin} />}
+          path={PATHS.login}
+          element={isLoggedIn ? <Navigate to={PATHS.explore} replace /> : <Login />}
         />
         <Route
-          path="/register"
-          element={isLoggedIn ? <Navigate to="/explore" replace /> : <Register onRegisterSuccess={handleLogin} />}
+          path={PATHS.register}
+          element={isLoggedIn ? <Navigate to={PATHS.explore} replace /> : <Register />}
         />
-        <Route path="/rooms/:roomId" element={<ProtectedRoute><ChatLayout /></ProtectedRoute>} />
-        <Route path="/explore" element={<ProtectedRoute><ExploreRooms /></ProtectedRoute>} />
+        <Route path={PATHS.room} element={<ProtectedRoute><ChatLayout /></ProtectedRoute>} />
+        <Route path={PATHS.explore} element={<ProtectedRoute><ExploreRooms /></ProtectedRoute>} />
         {/* 404 Not Found 페이지 처리 */}
         <Route path="*" element={<NotFound />} />
       </Routes>

--- a/frontend/src/styles/theme.css
+++ b/frontend/src/styles/theme.css
@@ -1,29 +1,20 @@
 :root {
-  /* Surface and Background Colors */
   --bg-primary: #0A0A0A;
   --bg-secondary: #121212;
   --bg-tertiary: #1A1A1A;
-  
-  /* Accent Colors (Neon Green) */
   --accent-primary: #00FF66;
   --accent-secondary: #00CC52;
   --accent-glow: rgba(0, 255, 102, 0.4);
-  
-  /* Text Colors */
+  --accent-blue: #00CCFF;
   --text-primary: #FFFFFF;
   --text-secondary: #A0A0A0;
   --text-tertiary: #666666;
-  
-  /* Borders and Dividers */
   --border-color: rgba(255, 255, 255, 0.1);
   --border-highlight: rgba(0, 255, 102, 0.2);
-
-  /* Radii */
+  --color-error: #FF7B7B;
   --radius-sm: 8px;
   --radius-md: 12px;
   --radius-lg: 16px;
   --radius-full: 9999px;
-
-  /* Fonts */
   --font-stack: 'Inter', system-ui, -apple-system, sans-serif;
 }


### PR DESCRIPTION
## 📌 브랜치 정보
`feat/connect-auth-api`

## 🏷️ 작업 유형 (Type of Change)
- [x] ✨ 기능 추가 (Feature)
- [x] 🐛 버그 수정 (Fix)
- [x] 🎨 UI/UX 및 디자인 변경 (Design)
- [x] ♻️ 리팩토링 (Refactor)
- [ ] 📝 문서 작업 (Docs)

## 🚀 작업 내용
- 회원가입, 로그인, 토큰 재발급, 로그아웃을 백엔드 인증 API와 실제로 연동했습니다.
- `AuthContext` 중심으로 인증 상태를 통합하고, 로그인 후에만 `explore` 화면으로 진입하도록 라우팅 흐름을 정리했습니다.
- 회원가입 완료 시 자동 로그인하지 않고 로그인 화면으로 이동한 뒤 직접 로그인하도록 인증 UX를 변경했습니다.
- 로그인/회원가입 화면의 뒤로가기 버튼이 항상 온보딩 페이지로 이동하도록 수정했습니다.
- `REACT_APP_API_HOST` 환경변수를 도입하고 API endpoint를 상수로 분리해 공통 관리하도록 정리했습니다.
- 페이지 이동 경로를 `PATHS` 상수로 분리하여 라우팅/네비게이션에서 하드코딩된 경로 문자열을 제거했습니다.
- `rooms` API도 공통 요청 구조로 분리하여 방 목록 조회, 방 생성, 채팅 진입 로직에서 하드코딩된 API URL을 제거했습니다.
- 테마 변수는 JS 주입 방식 대신 다시 CSS 변수 기준으로 정리했습니다.
- JSON이 아닌 응답이 올 때 `Unexpected token '<'` 대신 원인을 알기 쉬운 에러 메시지가 보이도록 요청 처리 로직을 보강했습니다.

## ✅ 체크리스트
- [x] `README.md`에 명시된 코딩 컨벤션 및 커밋 메시지 규칙을 준수했습니다.
- [x] 관련 없는 코드나 불필요한 주석을 포함하지 않았습니다.
- [x] 작업할 브랜치(예: `dev`)의 최신 상태를 pull 받아 충돌이 없는 것을 확인했습니다.
- [ ] (Backend) 람다 함수나 DB 스키마 변경 시 로컬/테스트 환경에서 검증을 완료했습니다.

## 💬 리뷰어에게
- 프론트 기준 인증 흐름과 rooms API 구조를 함께 정리한 PR입니다.
- 백엔드 서버가 `http://localhost:4000`에서 실행 중일 때 정상 동작하도록 맞췄고, 프론트에서는 `REACT_APP_API_HOST`로 호스트를 변경할 수 있게 했습니다.
- 회원가입 후 자동 로그인되던 기존 흐름을 “회원가입 완료 → 로그인 화면 이동 → 로그인 성공 후 explore 진입”으로 변경한 부분을 중점적으로 봐주시면 좋겠습니다.
- `rooms` 관련 호출은 공통 API 유틸로 옮겼지만, `CreateRoomModal`은 아직 성공 후 `window.location.reload()`를 사용하고 있어 이후 상태 기반 갱신으로 한 번 더 개선할 여지가 있습니다.
