### PR TITLE
Feat/server room

### DIFF
--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -1,5 +1,5 @@
 service: smart-study-backend
-frameworkVersion: '3'
+frameworkVersion: "3"
 
 plugins:
   - serverless-offline
@@ -7,10 +7,10 @@ plugins:
 custom:
   studentId: "inhatc-202647019"
   prefix: "smartstudy"
-  usersTableName:         "${self:custom.prefix}-Users"
-  roomsTableName:         "${self:custom.prefix}-Rooms"
-  connectionsTableName:   "${self:custom.prefix}-Connections"
-  messagesTableName:      "${self:custom.prefix}-Messages"
+  usersTableName: "${self:custom.prefix}-Users"
+  roomsTableName: "${self:custom.prefix}-Rooms"
+  connectionsTableName: "${self:custom.prefix}-Connections"
+  messagesTableName: "${self:custom.prefix}-Messages"
   refreshTokensTableName: "${self:custom.prefix}-RefreshTokens"
 
 provider:
@@ -23,9 +23,9 @@ provider:
     name: inhatc-team3-2-deployments
 
   environment:
-    REGION:            us-east-1
+    REGION: us-east-1
     # 암호화 관련
-    
+
     # 로컬 환경을 위해 수정
     JWT_SECRET_KEY: "local-secret-key-for-dev"
     SALT: "local-salt-value"
@@ -34,14 +34,14 @@ provider:
     # JWT_SECRET_KEY:    ${ssm:/smartstudy/dev/jwt-secret-key}
     # SALT:              ${ssm:/smartstudy/dev/salt}
     HASHING_ALGORITHM: HS256
-    S3_BUCKET:         ${env:S3_BUCKET, ""}
-    ALLOWED_ORIGIN:    ${env:ALLOWED_ORIGIN, "https://your-cloudfront-domain.net"}
-    RESOURCES_BUCKET:  "inhatc-team3-2-resources"
+    S3_BUCKET: ${env:S3_BUCKET, ""}
+    ALLOWED_ORIGIN: ${env:ALLOWED_ORIGIN, "https://your-cloudfront-domain.net"}
+    RESOURCES_BUCKET: "inhatc-team3-2-resources"
     # 테이블명 환경변수 (핸들러에서 process.env.USERS_TABLE 등으로 참조)
-    USERS_TABLE:        ${self:custom.usersTableName}
-    ROOMS_TABLE:        ${self:custom.roomsTableName}
-    CONNECTIONS_TABLE:  ${self:custom.connectionsTableName}
-    MESSAGES_TABLE:     ${self:custom.messagesTableName}
+    USERS_TABLE: ${self:custom.usersTableName}
+    ROOMS_TABLE: ${self:custom.roomsTableName}
+    CONNECTIONS_TABLE: ${self:custom.connectionsTableName}
+    MESSAGES_TABLE: ${self:custom.messagesTableName}
     REFRESH_TOKENS_TABLE: ${self:custom.refreshTokensTableName}
 
   # ── IAM 최소 권한 (SafeRole) ──────────────────────────────
@@ -135,12 +135,10 @@ provider:
   #     Resource:
   #       - "arn:aws:cognito-idp:us-east-1:*:userpool/smartstudy-*"
 
-
 # -------------------------------------------------------
 # Lambda 함수 목록
 # -------------------------------------------------------
 functions:
-
   # ── 방 관련 ──────────────────
   createRoom:
     handler: src/rooms/createRoom.handler
@@ -156,6 +154,24 @@ functions:
       - http:
           path: /rooms
           method: get
+          cors: true
+
+  # 접속한 유저 소속 방 목록 조회
+  getMyRooms:
+    handler: src/rooms/getMyRooms.handler
+    events:
+      - http:
+          path: /rooms/me
+          method: get
+          cors: true
+
+  # 서버방 참여 시 참여 유저 정보 저장
+  joinRoom:
+    handler: src/rooms/joinRoom.handler
+    events:
+      - http:
+          path: /rooms/{roomId}/join
+          method: post
           cors: true
 
   getRoomDetail:
@@ -222,7 +238,7 @@ functions:
           route: joinRoom
       - websocket:
           route: sendMessage
-  
+
   # ── 채널 추가/삭제 ───────────────────
   addChannel:
     handler: src/rooms/addChannel.handler
@@ -272,7 +288,6 @@ functions:
           path: /rooms/{roomId}/links
           method: post
           cors: true
-
 
 # -------------------------------------------------------
 # DynamoDB 테이블 정의 (CloudFormation)

--- a/backend/src/rooms/createRoom.js
+++ b/backend/src/rooms/createRoom.js
@@ -1,4 +1,3 @@
-// backend/src/rooms/createRoom.js
 const { PutCommand } = require("@aws-sdk/lib-dynamodb");
 const { v4: uuidv4 } = require("uuid");
 const dynamoDb = require("../dynamodbClient");
@@ -8,8 +7,8 @@ module.exports.handler = async (event) => {
   try {
     const body = JSON.parse(event.body || "{}");
 
-    // JWT 토큰에서 userId 추출
-    const authHeader = event.headers?.Authorization || event.headers?.authorization || "";
+    const authHeader =
+      event.headers?.Authorization || event.headers?.authorization || "";
     const { userId: hostId } = verifyAccessToken(authHeader);
 
     const roomId = uuidv4();
@@ -25,7 +24,7 @@ module.exports.handler = async (event) => {
         description: body.description || "",
         hostId: hostId || null,
         maxCapacity: body.maxCapacity || 10,
-        currentCount: 0,
+        currentCount: hostId ? 1 : 0, // 호스트가 있으면 1명, 없으면 0명으로 초기화
         members: hostId
           ? [{ userId: hostId, role: "HOST", joinedAt: createdAt }]
           : [],
@@ -39,7 +38,7 @@ module.exports.handler = async (event) => {
       headers: {
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Allow-Credentials": true,
-        "Content-Type": "application/json"
+        "Content-Type": "application/json",
       },
       body: JSON.stringify({
         message: "방 생성 성공",

--- a/backend/src/rooms/getMyRooms.js
+++ b/backend/src/rooms/getMyRooms.js
@@ -1,0 +1,73 @@
+const { ScanCommand } = require("@aws-sdk/lib-dynamodb");
+const dynamoDb = require("../dynamodbClient");
+const { verifyAccessToken } = require("../utils");
+
+// 내 유저 정보 기반으로 소속된 스터디룸 조회 핸들러
+exports.handler = async (event) => {
+  try {
+    const authHeader =
+      event.headers?.Authorization || event.headers?.authorization || "";
+    const { userId } = verifyAccessToken(authHeader);
+
+    if (!userId) {
+      return {
+        statusCode: 401,
+        headers: {
+          "Access-Control-Allow-Origin": "*",
+          "Access-Control-Allow-Credentials": true,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ message: "인증이 필요합니다." }),
+      };
+    }
+
+    const result = await dynamoDb.send(
+      new ScanCommand({
+        TableName: process.env.ROOMS_TABLE,
+      }),
+    );
+
+    const items = result.Items || [];
+    const myRooms = items.filter((room) => {
+      if (room.hostId === userId) {
+        return true;
+      }
+
+      if (!Array.isArray(room.members)) {
+        return false;
+      }
+
+      return room.members.some((member) => member?.userId === userId);
+    });
+
+    myRooms.sort((a, b) => {
+      const aDate = new Date(a.createdAt || 0).getTime();
+      const bDate = new Date(b.createdAt || 0).getTime();
+      return bDate - aDate;
+    });
+
+    return {
+      statusCode: 200,
+      headers: {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Allow-Credentials": true,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ items: myRooms }),
+    };
+  } catch (error) {
+    console.error("getMyRooms Error:", error);
+    return {
+      statusCode: 500,
+      headers: {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Allow-Credentials": true,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        message: "내 스터디룸 조회 실패",
+        error: error.message,
+      }),
+    };
+  }
+};

--- a/backend/src/rooms/joinRoom.js
+++ b/backend/src/rooms/joinRoom.js
@@ -1,0 +1,104 @@
+const { GetCommand, UpdateCommand } = require("@aws-sdk/lib-dynamodb");
+const dynamoDb = require("../dynamodbClient");
+const { verifyAccessToken } = require("../utils");
+
+// 방 참여 시 유저 정보 저장 핸들러
+exports.handler = async (event) => {
+  try {
+    const { roomId } = event.pathParameters || {};
+    const authHeader =
+      event.headers?.Authorization || event.headers?.authorization || "";
+    const { userId } = verifyAccessToken(authHeader);
+
+    if (!userId) {
+      return {
+        statusCode: 401,
+        headers: {
+          "Access-Control-Allow-Origin": "*",
+          "Access-Control-Allow-Credentials": true,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ message: "인증이 필요합니다." }),
+      };
+    }
+
+    if (!roomId) {
+      return {
+        statusCode: 400,
+        headers: {
+          "Access-Control-Allow-Origin": "*",
+          "Access-Control-Allow-Credentials": true,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ message: "roomId가 필요합니다." }),
+      };
+    }
+
+    const roomResult = await dynamoDb.send(
+      new GetCommand({
+        TableName: process.env.ROOMS_TABLE,
+        Key: { roomId },
+      }),
+    );
+
+    const room = roomResult.Item;
+
+    if (!room) {
+      return {
+        statusCode: 404,
+        headers: {
+          "Access-Control-Allow-Origin": "*",
+          "Access-Control-Allow-Credentials": true,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ message: "해당 방을 찾을 수 없습니다." }),
+      };
+    }
+
+    const members = Array.isArray(room.members) ? room.members : [];
+    const alreadyMember = members.some((member) => member?.userId === userId);
+
+    if (!alreadyMember) {
+      const nextMembers = [
+        ...members,
+        { userId, role: "MEMBER", joinedAt: new Date().toISOString() },
+      ];
+
+      await dynamoDb.send(
+        new UpdateCommand({
+          TableName: process.env.ROOMS_TABLE,
+          Key: { roomId },
+          UpdateExpression: "SET members = :members, currentCount = :count",
+          ExpressionAttributeValues: {
+            ":members": nextMembers,
+            ":count": nextMembers.length,
+          },
+        }),
+      );
+    }
+
+    return {
+      statusCode: 200,
+      headers: {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Allow-Credentials": true,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        message: alreadyMember ? "이미 참여 중인 방입니다." : "방 참여 성공",
+        roomId,
+      }),
+    };
+  } catch (error) {
+    console.error("joinRoom Error:", error);
+    return {
+      statusCode: 500,
+      headers: {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Allow-Credentials": true,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ message: "방 참여 실패", error: error.message }),
+    };
+  }
+};

--- a/frontend/src/components/Chat/ChatLayout.js
+++ b/frontend/src/components/Chat/ChatLayout.js
@@ -1,49 +1,52 @@
-// ChatLayout.js
-import React, { useState, useEffect } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
-import { PATHS } from '../../constants/path';
-import { getRoomDetail, getRoomMessages } from '../../lib/rooms';
-import './ChatLayout.css';
-import ServerSidebar from '../layout/ServerSidebar';
-import SidebarLeft from './SidebarLeft';
-import ChatWindow from './ChatWindow';
-import ResourceHub from './ResourceHub';
-import CreateRoomModal from '../Rooms/CreateRoomModal';
+import React, { useState, useEffect } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import { PATHS } from "../../constants/path";
+import { getRoomDetail, getRoomMessages } from "../../lib/rooms";
+import { useRooms } from "../../contexts/RoomContext";
+import "./ChatLayout.css";
+import ServerSidebar from "../layout/ServerSidebar";
+import SidebarLeft from "./SidebarLeft";
+import ChatWindow from "./ChatWindow";
+import ResourceHub from "./ResourceHub";
+import CreateRoomModal from "../Rooms/CreateRoomModal";
 
 const ChatLayout = () => {
-  const { roomId } = useParams(); // URL에서 roomId 추출
+  const { roomId } = useParams();
   const navigate = useNavigate();
+  const { setActiveRoomId, upsertJoinedRoom } = useRooms();
 
   const [currentRoom, setCurrentRoom] = useState(null);
-  const [loading, setLoading] = useState(true); 
-  
-  const [activeChannel, setActiveChannel] = useState('');
+  const [loading, setLoading] = useState(true);
+
+  const [activeChannel, setActiveChannel] = useState("");
   const [isModalOpen, setIsModalOpen] = useState(false);
 
   useEffect(() => {
     setLoading(true);
-    
-    // 방 상세 정보와 메시지 이력을 병렬로 호출
-    Promise.all([
-      getRoomDetail(roomId),
-      getRoomMessages(roomId)
-    ])
+    setActiveRoomId(roomId);
+
+    Promise.all([getRoomDetail(roomId), getRoomMessages(roomId)])
       .then(([roomData, messagesData]) => {
         // messages가 배열인지 items 안에 있는지 처리
-        const messages = Array.isArray(messagesData) ? messagesData : (messagesData?.items || []);
-        
+        const messages = Array.isArray(messagesData)
+          ? messagesData
+          : messagesData?.items || [];
+
         if (roomData) {
-          const channels = roomData.channels || [{ id: 'ch-general', name: '일반', label: '일반' }];
-          
+          const channels = roomData.channels || [
+            { id: "ch-general", name: "일반", label: "일반" },
+          ];
+
           const roomWithChannels = {
             ...roomData,
             channels: channels.map((ch, idx) => ({
               ...ch,
               label: ch.label || ch.name,
-              messages: idx === 0 ? messages : []
-            }))
+              messages: idx === 0 ? messages : [],
+            })),
           };
-          
+          upsertJoinedRoom(roomData);
+
           setCurrentRoom(roomWithChannels);
           if (channels.length > 0) {
             setActiveChannel(channels[0].id || channels[0].chId);
@@ -51,51 +54,59 @@ const ChatLayout = () => {
         }
         setLoading(false);
       })
-      .catch(err => {
+      .catch((err) => {
         console.error("방 정보를 가져오는 중 오류 발생:", err);
         setLoading(false);
       });
-  }, [roomId]);
+  }, [roomId, setActiveRoomId, upsertJoinedRoom]);
 
   // 로딩 중일 때 처리
-  if (loading) return <div style={{ color: 'white', padding: '20px' }}>방 정보를 가져오는 중...</div>;
+  if (loading)
+    return (
+      <div style={{ color: "white", padding: "20px" }}>
+        방 정보를 가져오는 중...
+      </div>
+    );
 
   // 진짜로 방이 없을 때 처리 (서버에도 없을 때)
   if (!currentRoom) {
     return (
-      <div style={{ padding: '20px', color: 'white' }}>
+      <div style={{ padding: "20px", color: "white" }}>
         <h3>방을 찾을 수 없습니다. (ID: {roomId})</h3>
-        <button onClick={() => navigate(PATHS.explore)}>목록으로 돌아가기</button>
+        <button onClick={() => navigate(PATHS.explore)}>
+          목록으로 돌아가기
+        </button>
       </div>
     );
   }
 
   return (
     <div className="chat-container">
-      <ServerSidebar 
-        activeView="chat" 
-        onServerClick={() => {}} 
+      <ServerSidebar
+        activeView="chat"
+        onServerClick={() => {}}
         onAddClick={() => setIsModalOpen(true)}
       />
 
-      <SidebarLeft 
-        roomName={currentRoom?.roomName || currentRoom?.title || "로딩 중..."} // 방 제목을 넘겨줌
-        channels={currentRoom?.channels || []} 
-        activeChannel={activeChannel} 
+      <SidebarLeft
+        roomName={currentRoom?.roomName || currentRoom?.title || "로딩 중..."}
+        channels={currentRoom?.channels || []}
+        activeChannel={activeChannel}
         onChannelClick={setActiveChannel}
       />
 
-      <main className="chat-content-wrapper" style={{ display: 'flex', flex: 1, minWidth: 0 }}>
-        <ChatWindow 
-          activeChannel={activeChannel} 
-          channels={currentRoom.channels} 
+      <main
+        className="chat-content-wrapper"
+        style={{ display: "flex", flex: 1, minWidth: 0 }}
+      >
+        <ChatWindow
+          activeChannel={activeChannel}
+          channels={currentRoom.channels}
         />
         <ResourceHub roomResources={currentRoom} />
       </main>
 
-      {isModalOpen && (
-        <CreateRoomModal onClose={() => setIsModalOpen(false)} />
-      )}
+      {isModalOpen && <CreateRoomModal onClose={() => setIsModalOpen(false)} />}
     </div>
   );
 };

--- a/frontend/src/components/Rooms/ExploreRooms.js
+++ b/frontend/src/components/Rooms/ExploreRooms.js
@@ -109,6 +109,13 @@ const ExploreRooms = () => {
     navigate(getRoomPath(roomId));
   };
 
+  const handleDirectJoin = () => {
+    if (!inviteCode.trim()) {
+      alert('코드 혹은 주소를 입력해주세요!');
+      return;
+    }
+  };
+
   return (
     <div className="explore-container">
       <ServerSidebar 
@@ -151,7 +158,7 @@ const ExploreRooms = () => {
             value={inviteCode}
             onChange={(e) => setInviteCode(e.target.value)}
           />
-          <button className="join-directly-btn">즉시 입장</button>
+          <button className="join-directly-btn" onClick={handleDirectJoin}>즉시 입장</button>
         </div>
 
         <div className="rooms-grid">

--- a/frontend/src/components/Rooms/ExploreRooms.js
+++ b/frontend/src/components/Rooms/ExploreRooms.js
@@ -1,31 +1,29 @@
-import React, { useState, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
-import { getRoomPath } from '../../constants/path';
-import { getRooms } from '../../lib/rooms';
-import './ExploreRooms.css';
-import ServerSidebar from '../layout/ServerSidebar';
-import CreateRoomModal from './CreateRoomModal';
-import { useAuth } from '../../contexts/AuthContext'; 
-import { PATHS } from '../../constants/path';
-// import AuthActionButton from '../common/AuthActionButton';
-// import { MOCK_ROOMS } from '../../data/mockData'; // 하드코딩 데이터
+import React, { useState, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import { getRoomPath } from "../../constants/path";
+import { getRooms, joinRoom } from "../../lib/rooms";
+import "./ExploreRooms.css";
+import ServerSidebar from "../layout/ServerSidebar";
+import CreateRoomModal from "./CreateRoomModal";
+import { useAuth } from "../../contexts/AuthContext";
+import { PATHS } from "../../constants/path";
+import { useRooms } from "../../contexts/RoomContext";
 
 const RoomCard = ({ room, onJoin }) => {
-  const name = room.roomName || room.title || "제목 없음";         
-  const roomId = room.roomId;        
+  const name = room.roomName || room.title || "제목 없음";
   const description = room.description;
   const currentMembers = Number(room.currentCount) || 0;
   const maxMembers = room.maxCapacity || 12;
   const coverImage = room.imageUrl || room.coverImage;
-  const emoji = "📚";                // 기본 이모지
-  
+  const emoji = "📚";
 
-  const isFull = (maxMembers && currentMembers >= maxMembers) || room.status === 'FULL';
+  const isFull =
+    (maxMembers && currentMembers >= maxMembers) || room.status === "FULL";
   const isLocked = room.isPrivate && isFull;
-  const displayStatus = isFull ? 'FULL' : room.status;
+  const displayStatus = isFull ? "FULL" : room.status;
 
   return (
-    <div className={`room-card ${isFull ? 'room-full' : ''}`}>
+    <div className={`room-card ${isFull ? "room-full" : ""}`}>
       <div className="room-cover">
         {/* 이미지가 있으면 <img> 태그를, 없으면 기존처럼 이모지를 보여줌 */}
         {coverImage ? (
@@ -33,7 +31,7 @@ const RoomCard = ({ room, onJoin }) => {
         ) : (
           <div className="room-cover-emoji">{emoji}</div>
         )}
-        
+
         <span className={`room-badge badge-${displayStatus.toLowerCase()}`}>
           {displayStatus}
         </span>
@@ -61,11 +59,15 @@ const RoomCard = ({ room, onJoin }) => {
           </div>
 
           {isLocked ? (
-            <button className="room-btn btn-locked" disabled>LOCKED</button>
+            <button className="room-btn btn-locked" disabled>
+              LOCKED
+            </button>
           ) : isFull ? (
-            <button className="room-btn btn-locked" disabled>FULL</button>
+            <button className="room-btn btn-locked" disabled>
+              FULL
+            </button>
           ) : (
-            <button className="room-btn btn-join" onClick={() => onJoin(roomId)}>
+            <button className="room-btn btn-join" onClick={() => onJoin(room)}>
               JOIN
             </button>
           )}
@@ -78,49 +80,61 @@ const RoomCard = ({ room, onJoin }) => {
 const ExploreRooms = () => {
   const navigate = useNavigate();
   const { logout } = useAuth();
+  const { clearJoinedRooms, setActiveRoomId, upsertJoinedRoom } = useRooms();
   const [rooms, setRooms] = useState([]);
-  const [searchQuery, setSearchQuery] = useState('');
-  const [inviteCode, setInviteCode] = useState('');
+  const [searchQuery, setSearchQuery] = useState("");
+  const [inviteCode, setInviteCode] = useState("");
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const handleLogout = () => { 
+  const handleLogout = () => {
     console.log("로그아웃 로직 실행");
+    clearJoinedRooms();
     logout();
     navigate(PATHS.onboarding);
-  }
+  };
 
   useEffect(() => {
+    setActiveRoomId(null);
     getRooms()
-    .then(data => setRooms(data.items || []))
-    .catch(err => {
-      console.error("데이터 로드 실패!", err);
-      setRooms([]);
-    });
-  }, []);
+      .then((data) => setRooms(data.items || []))
+      .catch((err) => {
+        console.error("데이터 로드 실패!", err);
+        setRooms([]);
+      });
+  }, [setActiveRoomId]);
 
-  const filteredRooms = rooms.filter(room => {
-    const title = room.roomName || room.title || "";  // roomName 우선
+  const filteredRooms = rooms.filter((room) => {
+    const title = room.roomName || room.title || "";
     const description = room.description || "";
-    return title.toLowerCase().includes(searchQuery.toLowerCase()) ||
-      description.toLowerCase().includes(searchQuery.toLowerCase());
+    return (
+      title.toLowerCase().includes(searchQuery.toLowerCase()) ||
+      description.toLowerCase().includes(searchQuery.toLowerCase())
+    );
   });
 
   // 방 입장 시 해당 ID의 주소로 이동
-  const handleJoinRoom = (roomId) => {
-    navigate(getRoomPath(roomId));
+  const handleJoinRoom = async (room) => {
+    try {
+      await joinRoom(room.roomId);
+      upsertJoinedRoom(room);
+      navigate(getRoomPath(room.roomId));
+    } catch (error) {
+      console.error("방 참여 실패:", error);
+      alert(error.message || "방 입장 중 오류가 발생했습니다.");
+    }
   };
 
   const handleDirectJoin = () => {
     if (!inviteCode.trim()) {
-      alert('코드 혹은 주소를 입력해주세요!');
+      alert("코드 혹은 주소를 입력해주세요!");
       return;
     }
   };
 
   return (
     <div className="explore-container">
-      <ServerSidebar 
-        activeView="home" 
-        onServerClick={() => {}} // 이미 홈임
+      <ServerSidebar
+        activeView="home"
+        onServerClick={() => {}}
         onAddClick={() => setIsModalOpen(true)}
         onLogout={handleLogout}
       />
@@ -128,15 +142,12 @@ const ExploreRooms = () => {
       <div className="explore-main">
         <div className="explore-topbar">
           <span className="topbar-title">스터디룸 탐색</span>
-          {/* <div className="topbar-icons">
-            <button className="icon-btn">🔔</button>
-            <button className="icon-btn">⚙️</button>
-          </div> */}
         </div>
 
         <div className="explore-hero">
           <h1 className="hero-title">
-            새로운 <span className="accent">스터디룸</span>을 찾거나 <span className="accent">생성</span>해보세요!
+            새로운 <span className="accent">스터디룸</span>을 찾거나{" "}
+            <span className="accent">생성</span>해보세요!
           </h1>
         </div>
 
@@ -158,15 +169,20 @@ const ExploreRooms = () => {
             value={inviteCode}
             onChange={(e) => setInviteCode(e.target.value)}
           />
-          <button className="join-directly-btn" onClick={handleDirectJoin}>즉시 입장</button>
+          <button className="join-directly-btn" onClick={handleDirectJoin}>
+            즉시 입장
+          </button>
         </div>
 
         <div className="rooms-grid">
-          {filteredRooms.map(room => (
+          {filteredRooms.map((room) => (
             <RoomCard key={room.roomId} room={room} onJoin={handleJoinRoom} />
           ))}
 
-          <div className="room-card create-card" onClick={() => setIsModalOpen(true)}>
+          <div
+            className="room-card create-card"
+            onClick={() => setIsModalOpen(true)}
+          >
             <div className="create-plus">+</div>
             <p className="create-label">방 만들기</p>
             <p className="create-sub">새로운 학습 세션 시작하기</p>
@@ -174,9 +190,7 @@ const ExploreRooms = () => {
         </div>
       </div>
 
-      {isModalOpen && (
-        <CreateRoomModal onClose={() => setIsModalOpen(false)} />
-      )}
+      {isModalOpen && <CreateRoomModal onClose={() => setIsModalOpen(false)} />}
     </div>
   );
 };

--- a/frontend/src/components/layout/ServerSidebar.css
+++ b/frontend/src/components/layout/ServerSidebar.css
@@ -85,8 +85,13 @@
   flex: 1; 
 }
 
-.dummy-bg-1 { background-color: #14532d; }
-.dummy-bg-2 { background-color: #064e3b; }
+.room-server-icon {
+  background-color: #14532d;
+  color: #dcfce7;
+  font-size: 16px;
+  font-weight: 800;
+  text-transform: uppercase;
+}
 
 /* ── 하단 프로필 영역 ── */
 .profile-wrapper {

--- a/frontend/src/components/layout/ServerSidebar.js
+++ b/frontend/src/components/layout/ServerSidebar.js
@@ -1,9 +1,10 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { PATHS } from '../../constants/path';
+import { getRoomPath, PATHS } from '../../constants/path';
 import { useAuth } from '../../contexts/AuthContext'; //
+import { useRooms } from '../../contexts/RoomContext';
 import './ServerSidebar.css';
- 
+
 /**
  * 극좌측 서버 네비게이션 바
  * @param {string} activeView - 현재 활성화된 뷰 ('home', 'chat' 등)
@@ -14,11 +15,12 @@ import './ServerSidebar.css';
 const ServerSidebar = ({ activeView, onServerClick, onAddClick, onLogout }) => {
   const navigate = useNavigate();
   const { user } = useAuth();
+  const { joinedRooms, activeRoomId } = useRooms();
   const [isProfileMenuOpen, setIsProfileMenuOpen] = useState(false);
   const menuRef = useRef(null);
 
   const initial = user?.nickname ? user.nickname.charAt(0) : '프'; // 닉네임의 첫 글자 추출 (정보가 없으면 '?' 표시)
- 
+
   // 메뉴 바깥 클릭 시 닫기
   useEffect(() => {
     const handleClickOutside = (e) => {
@@ -29,7 +31,7 @@ const ServerSidebar = ({ activeView, onServerClick, onAddClick, onLogout }) => {
     document.addEventListener('mousedown', handleClickOutside);
     return () => document.removeEventListener('mousedown', handleClickOutside);
   }, []);
- 
+
   const handleLogout = () => {
     setIsProfileMenuOpen(false);
     if (onLogout) onLogout();
@@ -42,24 +44,28 @@ const ServerSidebar = ({ activeView, onServerClick, onAddClick, onLogout }) => {
  
   return (
     <nav className="server-nav">
-      {/* 서버 아이콘들 */}
-      <div
-        className={`server-icon dummy-bg-1 ${activeView === 'chat' ? 'active-server' : ''}`}
-        onClick={onServerClick}
-        title="스터디룸 입장"
-      ></div>
- 
-      <div
-        className="server-icon dummy-bg-2"
-        onClick={onServerClick}
-        title="스터디룸 입장"
-      ></div>
- 
+      {joinedRooms.map((room) => {
+        const roomName = room.roomName || room.title || '';
+        const roomInitial = roomName ? roomName.trim().charAt(0).toUpperCase() : '?';
+        const isActiveRoom = activeView === 'chat' && room.roomId === activeRoomId;
+
+        return (
+          <div
+            key={room.roomId}
+            className={`server-icon room-server-icon ${isActiveRoom ? 'active-server' : ''}`}
+            onClick={() => navigate(getRoomPath(room.roomId))}
+            title={roomName || '접속한 스터디룸'}
+          >
+            {roomInitial}
+          </div>
+        );
+      })}
+
       {/* 서버 추가 버튼 */}
       <div className="server-icon add-btn" onClick={onAddClick} title="서버 추가">+</div>
- 
+
       <div className="spacer"></div>
- 
+
       {/* 하단 프로필 아바타 + 팝업 메뉴 */}
       <div className="profile-wrapper" ref={menuRef}>
         {/* 설정 팝업 메뉴 */}
@@ -79,7 +85,7 @@ const ServerSidebar = ({ activeView, onServerClick, onAddClick, onLogout }) => {
             </button>
           </div>
         )}
- 
+
         {/* 프로필 아바타 버튼 */}
         <div
           className="server-icon profile-icon"

--- a/frontend/src/constants/endpoint.js
+++ b/frontend/src/constants/endpoint.js
@@ -12,6 +12,7 @@ export const ENDPOINTS = {
   },
   rooms: {
     list: "/rooms",
+    mine: "/rooms/me",
   },
 };
 

--- a/frontend/src/contexts/RoomContext.js
+++ b/frontend/src/contexts/RoomContext.js
@@ -1,0 +1,110 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+import { useAuth } from "./AuthContext";
+import { getMyRooms } from "../lib/rooms";
+
+const RoomContext = createContext(null);
+/**
+ * @title 방 입장 퇴장 추적 및 동작 관리 컨텍스트
+ */
+
+export const RoomProvider = ({ children }) => {
+  const { isLoggedIn } = useAuth();
+  const [joinedRooms, setJoinedRooms] = useState([]);
+  const [activeRoomId, setActiveRoomId] = useState(null);
+
+  const upsertJoinedRoom = useCallback((room) => {
+    if (!room?.roomId) {
+      return;
+    }
+
+    const normalizedRoom = {
+      roomId: room.roomId,
+      roomName: room.roomName || room.title || "",
+    };
+
+    setJoinedRooms((prevRooms) => {
+      const existingIndex = prevRooms.findIndex(
+        (prevRoom) => prevRoom.roomId === normalizedRoom.roomId,
+      );
+
+      if (existingIndex === -1) {
+        return [...prevRooms, normalizedRoom];
+      }
+
+      return prevRooms.map((prevRoom, index) =>
+        index === existingIndex ? { ...prevRoom, ...normalizedRoom } : prevRoom,
+      );
+    });
+  }, []);
+
+  const clearJoinedRooms = useCallback(() => {
+    setJoinedRooms([]);
+    setActiveRoomId(null);
+  }, []);
+
+  useEffect(() => {
+    if (!isLoggedIn) {
+      clearJoinedRooms();
+      return;
+    }
+
+    let isMounted = true;
+
+    getMyRooms()
+      .then((data) => {
+        if (!isMounted) {
+          return;
+        }
+
+        const rooms = Array.isArray(data?.items) ? data.items : [];
+        setJoinedRooms(
+          rooms.map((room) => ({
+            roomId: room.roomId,
+            roomName: room.roomName || room.title || "",
+          })),
+        );
+      })
+      .catch((error) => {
+        if (!isMounted) {
+          return;
+        }
+
+        console.error("내 스터디룸 목록을 불러오지 못했습니다.", error);
+        setJoinedRooms([]);
+      });
+
+    return () => {
+      isMounted = false;
+    };
+  }, [isLoggedIn, clearJoinedRooms]);
+
+  const value = useMemo(
+    () => ({
+      joinedRooms,
+      activeRoomId,
+      setActiveRoomId,
+      upsertJoinedRoom,
+      clearJoinedRooms,
+    }),
+    [joinedRooms, activeRoomId, upsertJoinedRoom, clearJoinedRooms],
+  );
+
+  return <RoomContext.Provider value={value}>{children}</RoomContext.Provider>;
+};
+
+export const useRooms = () => {
+  const context = useContext(RoomContext);
+
+  if (!context) {
+    throw new Error("useRooms must be used within a RoomProvider");
+  }
+
+  return context;
+};

--- a/frontend/src/lib/rooms.js
+++ b/frontend/src/lib/rooms.js
@@ -7,6 +7,12 @@ export function getRooms() {
   });
 }
 
+export function getMyRooms() {
+  return request(ENDPOINTS.rooms.mine, {
+    method: "GET",
+  });
+}
+
 export function createRoom(payload) {
   return request(ENDPOINTS.rooms.list, {
     method: "POST",
@@ -23,5 +29,11 @@ export function getRoomDetail(roomId) {
 export function getRoomMessages(roomId) {
   return request(`${ENDPOINTS.rooms.list}/${roomId}/messages`, {
     method: "GET",
+  });
+}
+
+export function joinRoom(roomId) {
+  return request(`${ENDPOINTS.rooms.list}/${roomId}/join`, {
+    method: "POST",
   });
 }

--- a/frontend/src/pages/App.js
+++ b/frontend/src/pages/App.js
@@ -4,6 +4,7 @@ import "./App.css";
 
 // Context
 import { AuthProvider, useAuth } from "../contexts/AuthContext";
+import { RoomProvider, useRooms } from "../contexts/RoomContext";
 
 // Components
 import Onboarding from "../components/Onboarding/Onboarding";
@@ -29,6 +30,7 @@ const ProtectedRoute = ({ children }) => {
 function AppRoutes() {
   const navigate = useNavigate();
   const { isLoggedIn, refreshToken, logout } = useAuth();
+  const { clearJoinedRooms } = useRooms();
 
   const handleLogout = async () => {
     try {
@@ -39,6 +41,7 @@ function AppRoutes() {
     } catch (error) {
       console.error("Logout failed:", error);
     } finally {
+      clearJoinedRooms();
       logout();
       navigate(PATHS.onboarding, { replace: true });
     }
@@ -70,7 +73,9 @@ function AppRoutes() {
 function App() {
   return (
     <AuthProvider>
-      <AppRoutes />
+      <RoomProvider>
+        <AppRoutes />
+      </RoomProvider>
     </AuthProvider>
   );
 }


### PR DESCRIPTION
## 📌 관련 이슈
#(이슈 번호)

## 🏷️ 작업 유형 (Type of Change)
- [x] ✨ 기능 추가 (Feature)
- [x] 🐛 버그 수정 (Fix)
- [x] 🎨 UI/UX 및 디자인 변경 (Design)
- [ ] ♻️ 리팩토링 (Refactor)
- [ ] 📝 문서 작업 (Docs)

## 🚀 작업 내용
- 인증 상태 단일화: `App.js`에서 라우팅/로그인 상태를 `AuthContext` 기준으로 통합하여 `/login` ↔ `/explore` 무한 리다이렉트 및 `Maximum update depth exceeded` 문제를 수정
- 방 탐색 입력 검증 추가: `Explore` 페이지의 `즉시 입장` 버튼 클릭 시 입력값이 비어 있으면 `코드 혹은 주소를 입력해주세요!` 알림이 표시되도록 유효성 검사 및 alert 처리
- 소속 방 기반 사이드바 구현: `RoomContext`를 추가하고 로그인 후 `/rooms/me` API로 사용자가 소속된 방 목록을 불러와 좌측 사이드바에 서버 이름 첫 글자로 표시되도록 구현
- 방 참여/멤버십 흐름 연결: `POST /rooms/{roomId}/join` API를 추가하고 `JOIN` 시 DB의 `members`와 `currentCount`가 갱신되도록 연동
- 백엔드 방 조회 확장: `GET /rooms/me` API를 추가해 호스트 또는 멤버로 소속된 방만 조회할 수 있도록 구현하고, 생성된 방의 초기 멤버/인원 수 데이터 정합성을 보완
- 사이드바 이동 UX 개선: 사이드바에 표시된 소속 방 아이콘 클릭 시 해당 방(`/rooms/:roomId`)으로 바로 이동하도록 연결

## ✅ 체크리스트
- [x] `README.md`에 명시된 코딩 컨벤션 및 커밋 메시지 규칙을 준수했습니다.
- [x] 관련 없는 코드나 불필요한 주석을 포함하지 않았습니다.
- [x] 작업할 브랜치(예: `dev`)의 최신 상태를 pull 받아 충돌이 없는 것을 확인했습니다.
- [x] (Backend) 람다 함수나 DB 스키마 변경 시 로컬/테스트 환경에서 검증을 완료했습니다.

## 💬 리뷰어에게
- 사이드바는 “마지막 방문 방”이 아니라 “DB 기준으로 현재 사용자가 소속된 방”을 표시하도록 구현했습니다.
- `GET /rooms/me`, `POST /rooms/{roomId}/join` 엔드포인트를 추가했고, 프론트는 `RoomContext`를 통해 이 목록을 전역 상태로 관리합니다.
- 프론트 빌드는 `npm run build`로 검증했고, 백엔드 신규 핸들러는 로컬에서 로드 가능한지 확인했습니다.
- 진행 업무였던 
   - 스터디룸 입장의 경우, 이미 구현이 되어있어 추가로 작업한 내역이 없습니다.
   - 스터디룸 검색의 경우, 이미 제목 기반으로 검색할 수 있어 추가로 작업한 내역이 없습니다.
   - 소속 스터디룸을 사이드바에 띄우는 작업 내역은 위의 내용을 참고해주시면 됩니다.
- 내 소속 스터디룸 목록을 불러오는 엔드포인트를 백엔드 파트에서 한 작업이 아니다보니 검증을 한번 해주시면 감사하겠습니다.
- 직접 호스트가 되어 생성한 `방 삭제`와 이미 만들어져있는 방에 내가 접속한 `방 채널 삭제(퇴장)`의 경우 UI 상에서 어디에 아이콘을 두면 좋을지 배치하지 않아서 구현하지 않았습니다.
   - 버튼만 생성하면 붙일 수 있도록 로직 구현 중입니다.