### PR TITLE
Feat/server password logic

### DIFF
--- a/frontend/src/components/Rooms/CreateRoomModal.js
+++ b/frontend/src/components/Rooms/CreateRoomModal.js
@@ -6,17 +6,25 @@ const CreateRoomModal = ({ onClose }) => {
   const [groupName, setGroupName] = useState('');
   const [description, setDescription] = useState('');
   const [privacy, setPrivacy] = useState('Public');
+  const [roomPassword, setRoomPassword] = useState('');
   const [maxParticipants, setMaxParticipants] = useState(12);
   const [coverImage, setCoverImage] = useState(null);
 
   const handleSubmit = async (e) => {
   e.preventDefault();
 
+  if(privacy === 'Private' && !roomPassword) {
+    alert("비공개 방은 비밀번호 설정이 필수입니다.");
+    return;
+  }
+
   // 서버가 기대하는 이름표(title)로 데이터를 포장합니다.
   const newRoomData = {
     roomName: groupName,        // title -> roomName
     description: description,
     maxCapacity: Number(maxParticipants), // 정원 정보도 백엔드 필드명에 맞춤
+    isPrivate: privacy === 'Private', // 비공개 여부 추가
+    roomPassword: privacy ==='Private' ? roomPassword : '', // 비밀번호 추가
     status: 'ACTIVE',
   };
 
@@ -74,7 +82,10 @@ const CreateRoomModal = ({ onClose }) => {
                 <button 
                   type="button" 
                   className={privacy === 'Public' ? 'active' : ''}
-                  onClick={() => setPrivacy('Public')}
+                  onClick={() => {
+                    setPrivacy('Public');
+                    setRoomPassword(''); // 공개 전환 시 비밀번호 초기화
+                  }}
                 >
                   공개
                 </button>
@@ -100,6 +111,21 @@ const CreateRoomModal = ({ onClose }) => {
               </select>
             </div>
           </div>
+
+          {/* 5. 비공개 선택 시에만 나타나는 비밀번호 입력란 */}
+          {privacy === 'Private' && (
+            <div className="form-group animate-fade-in">
+              <label>방 비밀번호</label>
+              <input 
+                type="password" 
+                placeholder="입장 시 사용할 비밀번호를 입력하세요"
+                value={roomPassword}
+                onChange={(e) => setRoomPassword(e.target.value)}
+                required={privacy === 'Private'}
+                autoComplete="new-password"
+              />
+            </div>
+          )}
 
           <div className="form-group">
             <label>커버 이미지 업로드</label>

--- a/frontend/src/components/Rooms/CreateRoomModal.js
+++ b/frontend/src/components/Rooms/CreateRoomModal.js
@@ -6,14 +6,14 @@ const CreateRoomModal = ({ onClose }) => {
   const [groupName, setGroupName] = useState('');
   const [description, setDescription] = useState('');
   const [privacy, setPrivacy] = useState('Public');
-  const [roomPassword, setRoomPassword] = useState('');
+  const [serverPassword, setServerPassword] = useState('');
   const [maxParticipants, setMaxParticipants] = useState(12);
   const [coverImage, setCoverImage] = useState(null);
 
   const handleSubmit = async (e) => {
   e.preventDefault();
 
-  if(privacy === 'Private' && !roomPassword) {
+  if(privacy === 'Private' && !serverPassword) {
     alert("비공개 방은 비밀번호 설정이 필수입니다.");
     return;
   }
@@ -24,7 +24,7 @@ const CreateRoomModal = ({ onClose }) => {
     description: description,
     maxCapacity: Number(maxParticipants), // 정원 정보도 백엔드 필드명에 맞춤
     isPrivate: privacy === 'Private', // 비공개 여부 추가
-    roomPassword: privacy ==='Private' ? roomPassword : '', // 비밀번호 추가
+    serverPassword: privacy ==='Private' ? serverPassword : '', // 비밀번호 추가
     status: 'ACTIVE',
   };
 
@@ -84,7 +84,7 @@ const CreateRoomModal = ({ onClose }) => {
                   className={privacy === 'Public' ? 'active' : ''}
                   onClick={() => {
                     setPrivacy('Public');
-                    setRoomPassword(''); // 공개 전환 시 비밀번호 초기화
+                    setServerPassword(''); // 공개 전환 시 비밀번호 초기화
                   }}
                 >
                   공개
@@ -119,8 +119,8 @@ const CreateRoomModal = ({ onClose }) => {
               <input 
                 type="password" 
                 placeholder="입장 시 사용할 비밀번호를 입력하세요"
-                value={roomPassword}
-                onChange={(e) => setRoomPassword(e.target.value)}
+                value={serverPassword}
+                onChange={(e) => setServerPassword(e.target.value)}
                 required={privacy === 'Private'}
                 autoComplete="new-password"
               />

--- a/frontend/src/components/Rooms/ExploreRooms.css
+++ b/frontend/src/components/Rooms/ExploreRooms.css
@@ -336,3 +336,13 @@
   color: #52525b;
   letter-spacing: 0.5px;
 }
+
+/* 비밀번호 입력창이 나타날 때 부드럽게 보여주는 효과 */
+.animate-fade-in {
+  animation: fadeIn 0.3s ease-out;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; transform: translateY(-10px); }
+  to { opacity: 1; transform: translateY(0); }
+}


### PR DESCRIPTION
## 📌 관련 이슈
#(이슈 번호)

## 🏷️ 작업 유형 (Type of Change)
- [x] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Fix)
- [x] 🎨 UI/UX 및 디자인 변경 (Design)
- [x] ♻️ 리팩토링 (Refactor)
- [ ] 📝 문서 작업 (Docs)

## 🚀 작업 내용
비공개 스터디룸 비밀번호 기능 구현
- CreateRoomModal 내 '비공개' 선택 시 비밀번호 입력 필드가 나타나도록 조건부 렌더링 구현
- 방 생성 시 서버로 isPrivate 여부와 비밀번호 데이터를 전송하도록 로직 확장

코드 일관성을 위한 리팩토링
- 방 비밀번호 관련 변수/상태명을 roomPassword에서 serverPassword로 일괄 변경

## ✅ 체크리스트
- [x] `README.md`에 명시된 코딩 컨벤션 및 커밋 메시지 규칙을 준수했습니다.
- [x] 관련 없는 코드나 불필요한 주석을 포함하지 않았습니다.
- [x] 작업할 브랜치(예: `dev`)의 최신 상태를 pull 받아 충돌이 없는 것을 확인했습니다.
- [x] (Backend) 람다 함수나 DB 스키마 변경 시 로컬/테스트 환경에서 검증을 완료했습니다.

## 💬 리뷰어에게
- 데이터 구조: 현재 프론트에서 serverPassword라는 이름으로 데이터를 보내고 있습니다. 백엔드 API에서 해당 필드값을 정상적으로 수신하여 DB에 저장하는지 확인 부탁드립니다.
