### PR TITLE
feat: 서버 삭제/나가기 기능 및 규칙 관리 구현 (UI 실시간 동기화)

### DIFF
--- a/backend/infra/seedData.js
+++ b/backend/infra/seedData.js
@@ -90,7 +90,12 @@ const seedServers = [
     description: "Next.js와 TypeScript를 활용한 프로젝트 협업",
     status: "ACTIVE",
     isPrivate: true,
-    roomPassword: "1234",
+    serverPassword: "1234",
+    rules: [
+      { text: "1시간 공부 후 10분 휴식", icon: "✔️" },
+      { text: "캠 스터디 필수", icon: "✔️" },
+      { text: "잡담 금지", icon: "❌" }
+    ],
     createdAt: new Date(Date.now() - 3600000).toISOString(),
     expiresAt: Math.floor(Date.now() / 1000) + 86400 * 30,
     channels: [

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -464,7 +464,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.1021.0.tgz",
       "integrity": "sha512-Yp7p5HZh4ZAOqV7kbOP8ClPGJxFUTm+FRYLQAsA3x22rB3Q+rgcr+avBNxjS2AX7NeRCI6LY4zoeVYvILWEq3Q==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
@@ -7142,7 +7141,6 @@
       "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 10.16.0"
       }
@@ -7592,7 +7590,6 @@
       "integrity": "sha512-ek8NRg/OPvS9ISOJNWNAz5vZcpYacWNFDWNJjj5OXsc6YuKacfey6wF04cXz/tOJIVrZ2nGSkHpAY5qKtF6ISg==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "d": "^1.0.2",
         "duration": "^0.2.2",
@@ -9067,7 +9064,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@aws-sdk/client-api-gateway": "^3.588.0",
         "@aws-sdk/client-cognito-identity-provider": "^3.588.0",
@@ -10472,7 +10468,6 @@
       "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8.3.0"
       },

--- a/backend/src/servers/createServer.js
+++ b/backend/src/servers/createServer.js
@@ -14,6 +14,11 @@ module.exports.handler = async (event) => {
     const serverId = uuidv4();
     const createdAt = new Date().toISOString();
 
+    const defaultRules = [
+    { text: "서로 존중하기", icon: "✔️" },
+    { text: "비매너 행동 금지", icon: "❌" }
+    ];
+
     // 호스트의 nickname을 Users 테이블에서 조회
     let hostNickname = "Unknown";
     if (hostId) {
@@ -31,14 +36,15 @@ module.exports.handler = async (event) => {
         serverId,
         status: "ACTIVE",
         createdAt,
-        serverName: body.serverName || body.roomName || "기본 스터디 서버",
+        serverName: body.serverName || "기본 스터디 서버",
         description: body.description || "",
         hostId: hostId || null,
         hostNickname,
         maxCapacity: body.maxCapacity || 10,
         currentCount: hostId ? 1 : 0,
         isPrivate: body.isPrivate || false,
-        password: body.password || null,
+        serverPassword: body.serverPassword || null,
+        rules: body.rules || defaultRules,
         channels: [
           { chId: uuidv4(), name: "일반", label: "일반", topic: "", isDefault: true },
         ],

--- a/backend/src/servers/deleteServer.js
+++ b/backend/src/servers/deleteServer.js
@@ -12,16 +12,12 @@ exports.handler = async (event) => {
     if (error || !userId) {
       return {
         statusCode: 401,
-        headers: { "Access-Control-Allow-Origin": "*", "Content-Type": "application/json" },
+        headers: { 
+          "Access-Control-Allow-Origin": "*",
+          "Access-Control-Allow-Credentials": true,
+          "Content-Type": "application/json" 
+        },
         body: JSON.stringify({ message: "인증이 필요합니다." }),
-      };
-    }
-
-    if (!serverId) {
-      return {
-        statusCode: 400,
-        headers: { "Access-Control-Allow-Origin": "*", "Content-Type": "application/json" },
-        body: JSON.stringify({ message: "serverId가 필요합니다." }),
       };
     }
 
@@ -33,7 +29,10 @@ exports.handler = async (event) => {
     if (!serverResult.Item) {
       return {
         statusCode: 404,
-        headers: { "Access-Control-Allow-Origin": "*", "Content-Type": "application/json" },
+        headers: { 
+          "Access-Control-Allow-Origin": "*", 
+          "Content-Type": "application/json" 
+        },
         body: JSON.stringify({ message: "해당 서버를 찾을 수 없습니다." }),
       };
     }
@@ -41,8 +40,11 @@ exports.handler = async (event) => {
     if (serverResult.Item.hostId !== userId) {
       return {
         statusCode: 403,
-        headers: { "Access-Control-Allow-Origin": "*", "Content-Type": "application/json" },
-        body: JSON.stringify({ message: "방장만 삭제할 수 있습니다." }),
+        headers: {
+          "Access-Control-Allow-Origin": "*", 
+          "Content-Type": "application/json" 
+        },
+        body: JSON.stringify({ message: "서버 삭제는 호스트만 가능합니다." }),
       };
     }
 
@@ -50,6 +52,29 @@ exports.handler = async (event) => {
       TableName: process.env.SERVERS_TABLE,
       Key: { serverId },
     }));
+
+    // ServerMembers 테이블에서 해당 서버의 모든 멤버 데이터 삭제
+    try {
+      const members = await dynamoDb.send(new QueryCommand({
+        TableName: process.env.SERVER_MEMBERS_TABLE,
+        IndexName: "serverId-index", // serverId로 검색 가능한 인덱스가 있다고 가정
+        KeyConditionExpression: "serverId = :sid",
+        ExpressionAttributeValues: { ":sid": serverId },
+      }));
+
+      if (members.Items && members.Items.length > 0) {
+        // 배치 삭제 처리
+        const deleteRequests = members.Items.map(member => ({
+          DeleteRequest: { Key: { userId: member.userId, serverId: member.serverId } }
+        }));
+        
+        await dynamoDb.send(new BatchWriteCommand({
+          RequestItems: { [process.env.SERVER_MEMBERS_TABLE]: deleteRequests }
+        }));
+      }
+    } catch (memberErr) {
+      console.warn("멤버 데이터 삭제 중 경고 (무시 가능):", memberErr);
+    }
 
     return {
       statusCode: 200,

--- a/backend/src/servers/joinServer.js
+++ b/backend/src/servers/joinServer.js
@@ -69,9 +69,10 @@ exports.handler = async (event) => {
     }
 
     // 4. 비밀번호 검증 (비공개 서버)
-    if (serverResult.Item.password) {
+    if (serverResult.Item.serverPassword) {
       const body = JSON.parse(event.body || "{}");
-      if (!body.password || body.password !== serverResult.Item.password) {
+
+      if (!body.serverPassword || body.serverPassword !== serverResult.Item.serverPassword) {
         return {
           statusCode: 403,
           headers: { "Access-Control-Allow-Origin": "*", "Content-Type": "application/json" },

--- a/backend/src/servers/leaveServer.js
+++ b/backend/src/servers/leaveServer.js
@@ -1,0 +1,32 @@
+const { DeleteCommand, UpdateCommand } = require("@aws-sdk/lib-dynamodb");
+const dynamoDb = require("../dynamodbClient");
+const { verifyAccessToken } = require("../utils");
+
+exports.handler = async (event) => {
+  try {
+    const { serverId } = event.pathParameters;
+    const { userId } = verifyAccessToken(event.headers?.Authorization);
+
+    // 멤버 테이블에서 내 데이터 삭제
+    await dynamoDb.send(new DeleteCommand({
+      TableName: process.env.SERVER_MEMBERS_TABLE,
+      Key: { userId, serverId },
+    }));
+
+    // 서버 테이블의 현재 인원수(currentCount) -1 감소
+    await dynamoDb.send(new UpdateCommand({
+      TableName: process.env.SERVERS_TABLE,
+      Key: { serverId },
+      UpdateExpression: "SET currentCount = currentCount - :val",
+      ExpressionAttributeValues: { ":val": 1 },
+    }));
+
+    return {
+      statusCode: 200,
+      headers: { "Access-Control-Allow-Origin": "*", "Access-Control-Allow-Credentials": true },
+      body: JSON.stringify({ message: "서버에서 나갔습니다." }),
+    };
+  } catch (error) {
+    return { statusCode: 500, body: JSON.stringify({ error: error.message }) };
+  }
+};

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -68,7 +68,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -718,7 +717,6 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.28.6.tgz",
       "integrity": "sha512-D+OrJumc9McXNEBI/JmFnc/0uCM2/Y3PEBG3gfV3QIYkKv5pvnpzFrl1kYCrcHJP8nOeFB/SHi1IHz29pNGuew==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.28.6"
       },
@@ -1602,7 +1600,6 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.28.6.tgz",
       "integrity": "sha512-61bxqhiRfAACulXSLd/GxqmAedUSrRZIu/cbaT18T1CetkTmtDN15it7i80ru4DVqRK1WMxQhXs+Lf9kajm5Ow==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.27.3",
         "@babel/helper-module-imports": "^7.28.6",
@@ -3371,7 +3368,6 @@
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -3849,7 +3845,6 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.62.0.tgz",
       "integrity": "sha512-TiZzBSJja/LbhNPvk6yc0JrX9XqhQ0hdh6M2svYfsHGejaKFIAGd9MQ+ERIMzLGlN/kZoYIgdxFV0PuljTKXag==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.4.0",
         "@typescript-eslint/scope-manager": "5.62.0",
@@ -3903,7 +3898,6 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.62.0.tgz",
       "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.62.0",
         "@typescript-eslint/types": "5.62.0",
@@ -4273,7 +4267,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4372,7 +4365,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -5285,7 +5277,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -7120,7 +7111,6 @@
       "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -9864,7 +9854,6 @@
       "resolved": "https://registry.npmjs.org/jest/-/jest-27.5.1.tgz",
       "integrity": "sha512-Yn0mADZB89zTtjkPJEXwrac3LHudkQMR+Paqa8uxJHCBr9agxztUifWCyiYrjhMPBoUVBjyny0I7XH6ozDr7QQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "^27.5.1",
         "import-local": "^3.0.2",
@@ -10762,7 +10751,6 @@
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -12127,7 +12115,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -13262,7 +13249,6 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
       "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -13631,7 +13617,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -13763,7 +13748,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -13804,7 +13788,6 @@
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
       "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -14302,7 +14285,6 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.80.0.tgz",
       "integrity": "sha512-cIFJOD1DESzpjOBl763Kp1AH7UE/0fcdHe6rZXUdQ9c50uvgigvW97u3IcSeBwOkgqL/PXPBktBCh0KEu5L8XQ==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -14545,7 +14527,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -15700,6 +15681,23 @@
         }
       }
     },
+    "node_modules/tailwindcss/node_modules/yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
     "node_modules/tapable": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.2.tgz",
@@ -15916,7 +15914,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -16085,7 +16082,6 @@
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
       "license": "(MIT OR CC0-1.0)",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -16515,7 +16511,6 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.105.4.tgz",
       "integrity": "sha512-jTywjboN9aHxFlToqb0K0Zs9SbBoW4zRUlGzI2tYNxVYcEi/IPpn+Xi4ye5jTLvX2YeLuic/IvxNot+Q1jMoOw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -16587,7 +16582,6 @@
       "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.15.2.tgz",
       "integrity": "sha512-0XavAZbNJ5sDrCbkpWL8mia0o5WPOd2YGtxrEiZkBK9FjLppIUK2TgxK6qGD2P3hUXTJNNPVibrerKcx5WkR1g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/bonjour": "^3.5.9",
         "@types/connect-history-api-fallback": "^1.3.5",
@@ -17001,7 +16995,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",

--- a/frontend/src/components/Servers/CreateServerModal.js
+++ b/frontend/src/components/Servers/CreateServerModal.js
@@ -36,6 +36,12 @@ const serverFields = [
     required: true,
   },
   {
+    name: "rulesInput", // 임시 입력 필드
+    label: "서버 규칙 (줄바꿈으로 구분)",
+    type: "textarea", // 텍스트 영역으로 여러 줄 입력
+    placeholder: "예:\n욕설 금지\n1시간 공부 후 10분 휴식\n존재의 위기 느끼기 금지",
+  },
+  {
     name: "maxParticipants",
     label: "Max Participants",
     type: "select",
@@ -62,16 +68,29 @@ const CreateServerModal = ({ onClose }) => {
     if(isPrivate && !values.serverPassword) {
       alert("비공개 서버는 비밀번호 설정이 필수입니다!");
       return;
+    
     }
+
+    const rulesArray = values.rulesInput
+      ? values.rulesInput
+          .split("\n") // 줄바꿈으로 나누기
+          .map((line) => line.trim()) // 공백 제거
+          .filter((line) => line !== "") // 빈 줄 제외
+          .map((line) => ({
+            text: line,
+            // '금지'나 '❌'가 포함되면 ❌ 아이콘, 아니면 ✔️ 아이콘 자동 배정
+            icon: line.includes("금지") || line.includes("❌") || line.includes("안됨") ? "❌" : "✔️",
+          }))
+      : [];
 
     const newServerData = {
       serverName: values.serverName,
       description: values.description,
       maxCapacity: Number(values.maxParticipants),
       isPrivate: isPrivate,
-      roomPassword: isPrivate ? values.serverPassword : "",
+      serverPassword: isPrivate ? values.serverPassword : "",
+      rules: rulesArray,
       status: "ACTIVE",
-      // isPrivate: values.privacy === "Private",
     };
 
     try {

--- a/frontend/src/components/Servers/ExploreServers.js
+++ b/frontend/src/components/Servers/ExploreServers.js
@@ -86,7 +86,6 @@ const ExploreServers = () => {
   const { logout } = useAuth();
   const { exploreServers, setExploreServers, clearJoinedServers, setActiveServerId, upsertJoinedServer } =
     useServers();
-  const [servers, setServers] = useState([]);
   const [searchQuery, setSearchQuery] = useState("");
   const [inviteCode, setInviteCode] = useState("");
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -106,7 +105,6 @@ const ExploreServers = () => {
       .then((data) => { setExploreServers(data.items || []); })
       .catch((err) => {
         console.error("데이터 로드 실패!", err);
-        setServers([]);
       });
   }, [setActiveServerId, setExploreServers]);
 
@@ -127,40 +125,13 @@ const ExploreServers = () => {
       navigate(getServerPath(server.serverId));
     } catch (error) {
       console.error("서버 참여 실패:", error);
-      // FormModal의 내부 에러 처리를 위해 에러를 다시 던져줍니다.
-      // throw new Error(error.message || "서버 입장 중 오류가 발생했습니다.");
       throw error;
     }
   };
 
-  // 서버 입장 시 해당 ID의 주소로 이동
-  // const handleJoinServer = async (server) => {
-  //   try {
-  //     let password = null;
-  //     // 비공개 서버면 비밀번호 입력 받기
-  //     if (server.isPrivate) {
-  //       password = prompt("비공개 서버입니다. 비밀번호를 입력하세요:");
-  //       if (password === null) return; // 취소 누르면 중단
-  //     }
-  //     await joinServer(server.serverId, password);
-  //     upsertJoinedServer(server);
-  //     navigate(getServerPath(server.serverId));
-  //   } catch (error) {
-  //     console.error("서버 참여 실패:", error);
-  //     alert(error.message || "서버 입장 중 오류가 발생했습니다.");
-  //   }
-  // };
-
   const handleJoinClick = (server) => {
-    // if (server.isPrivate) {
-      // 비공개면 모달 띄우기
       setSelectedServer(server);
       setIsJoinModalOpen(true);
-    // }
-    // else {
-    //   // 공개면 바로 입장
-    //   executeJoin(server);
-    // }
   };
 
   const handleDirectJoin = () => {

--- a/frontend/src/components/Servers/ExploreServers.js
+++ b/frontend/src/components/Servers/ExploreServers.js
@@ -84,7 +84,7 @@ const ServerCard = ({ server, onJoin }) => {
 const ExploreServers = () => {
   const navigate = useNavigate();
   const { logout } = useAuth();
-  const { clearJoinedServers, setActiveServerId, upsertJoinedServer } =
+  const { exploreServers, setExploreServers, clearJoinedServers, setActiveServerId, upsertJoinedServer } =
     useServers();
   const [servers, setServers] = useState([]);
   const [searchQuery, setSearchQuery] = useState("");
@@ -103,14 +103,14 @@ const ExploreServers = () => {
   useEffect(() => {
     setActiveServerId(null);
     getServers()
-      .then((data) => setServers(data.items || []))
+      .then((data) => { setExploreServers(data.items || []); })
       .catch((err) => {
         console.error("데이터 로드 실패!", err);
         setServers([]);
       });
-  }, [setActiveServerId]);
+  }, [setActiveServerId, setExploreServers]);
 
-  const filteredServers = servers.filter((server) => {
+  const filteredServers = exploreServers.filter((server) => {
     const title = server.serverName || server.title || "";
     const description = server.description || "";
     return (
@@ -128,7 +128,8 @@ const ExploreServers = () => {
     } catch (error) {
       console.error("서버 참여 실패:", error);
       // FormModal의 내부 에러 처리를 위해 에러를 다시 던져줍니다.
-      throw new Error(error.message || "서버 입장 중 오류가 발생했습니다.");
+      // throw new Error(error.message || "서버 입장 중 오류가 발생했습니다.");
+      throw error;
     }
   };
 
@@ -151,14 +152,15 @@ const ExploreServers = () => {
   // };
 
   const handleJoinClick = (server) => {
-    if (server.isPrivate) {
+    // if (server.isPrivate) {
       // 비공개면 모달 띄우기
       setSelectedServer(server);
       setIsJoinModalOpen(true);
-    } else {
-      // 공개면 바로 입장
-      executeJoin(server);
-    }
+    // }
+    // else {
+    //   // 공개면 바로 입장
+    //   executeJoin(server);
+    // }
   };
 
   const handleDirectJoin = () => {
@@ -237,10 +239,9 @@ const ExploreServers = () => {
         <CreateServerModal onClose={() => setIsModalOpen(false)} />
       )}
 
-      {/* ⭐ 4. 서버 참가 비밀번호 모달 추가 */}
       {isJoinModalOpen && (
         <JoinServerModal
-          serverName={selectedServer?.serverName || selectedServer?.title}
+          server={selectedServer}
           onClose={() => setIsJoinModalOpen(false)}
           onSubmit={(password) => executeJoin(selectedServer, password)}
         />

--- a/frontend/src/components/Servers/JoinServerModal.css
+++ b/frontend/src/components/Servers/JoinServerModal.css
@@ -1,0 +1,132 @@
+/* frontend/src/components/Servers/JoinServerModal.css */
+.join-modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.85);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 2000;
+  backdrop-filter: blur(4px);
+}
+
+.join-modal-content {
+  background: #121212;
+  width: 100%;
+  max-width: 420px;
+  padding: 40px 32px;
+  border-radius: 32px;
+  border: 1px solid #333;
+  position: relative;
+  color: #fff;
+}
+
+.close-x {
+  position: absolute;
+  top: 20px;
+  right: 20px;
+  background: none;
+  border: none;
+  color: #666;
+  font-size: 28px;
+  cursor: pointer;
+}
+
+.private-badge {
+  background: #006400;
+  color: #fff;
+  padding: 4px 14px;
+  border-radius: 20px;
+  font-size: 12px;
+  width: fit-content;
+  margin: 0 auto 16px;
+}
+
+.server-desc-small { color: #888; font-size: 14px; margin: 0; }
+.server-name-large { font-size: 26px; margin: 8px 0 24px; }
+
+.server-stats {
+  display: flex;
+  justify-content: space-between;
+  font-size: 13px;
+  border-bottom: 1px solid #222;
+  padding-bottom: 20px;
+  margin-bottom: 24px;
+}
+
+.host-profile { display: flex; align-items: center; gap: 8px; }
+.avatar-circle { width: 24px; height: 24px; background: #444; border-radius: 50%; }
+.member-status { color: #888; }
+.dot { color: #00ff00; margin-right: 4px; }
+
+.rules-box {
+  background: #1e1e1e;
+  padding: 20px;
+  border-radius: 16px;
+  margin-bottom: 24px;
+  text-align: left;
+}
+
+.rules-title { font-size: 15px; font-weight: bold; margin-bottom: 12px; text-align: center; }
+.rules-list { list-style: none; padding: 0; margin: 0; }
+.rules-list li { display: flex; gap: 10px; margin-bottom: 8px; font-size: 14px; color: #bbb; }
+
+.input-label {
+  display: block;
+  text-align: left;
+  color: #39ff14; /* Neon Green */
+  font-size: 12px;
+  margin-bottom: 8px;
+}
+
+.pw-input {
+  width: 100%;
+  background: #2a2a2a;
+  border: 1px solid #444;
+  padding: 14px;
+  border-radius: 12px;
+  color: #fff;
+  margin-bottom: 24px;
+}
+
+.button-group { display: flex; justify-content: space-between; align-items: center; }
+.btn-cancel { background: none; border: none; color: #888; cursor: pointer; }
+.btn-enter {
+  background: #39ff14;
+  color: #000;
+  padding: 12px 32px;
+  border-radius: 24px;
+  font-weight: bold;
+  border: none;
+  cursor: pointer;
+}
+
+.password-field {
+  margin-bottom: 24px;
+}
+
+/* 공개 서버일 때(비밀번호 칸이 없을 때) 버튼 그룹 상단 여백 */
+.join-input-section {
+  margin-top: 10px;
+}
+
+/* 에러 메시지 텍스트 */
+.error-msg-text {
+  color: #ff4d4d;
+  font-size: 12px;
+  margin-top: 8px;
+  text-align: left;
+  animation: shake 0.2s ease-in-out; /* 살짝 흔들리는 효과(선택) */
+}
+
+/* 에러 시 인풋 테두리 변경 */
+.pw-input.input-error {
+  border: 1px solid #ff4d4d;
+}
+
+/* 에러 났을 때 흔들리는 애니메이션 */
+@keyframes shake {
+  0%, 100% { transform: translateX(0); }
+  25% { transform: translateX(-5px); }
+  75% { transform: translateX(5px); }
+}

--- a/frontend/src/components/Servers/JoinServerModal.js
+++ b/frontend/src/components/Servers/JoinServerModal.js
@@ -1,33 +1,83 @@
-import React from "react";
-import FormModal from "../common/FormModal";
+import React, { useState } from "react";
+import "./JoinServerModal.css"
 
-const joinFields = [
-  {
-    name: "password", // 백엔드 joinServer.js가 'password'라는 키를 기다리고 있으므로 이름을 맞춤.
-    label: "Server Password",
-    type: "password", // 입력 시 '****'로 가려지게 설정
-    placeholder: "비밀번호를 입력하세요",
-    required: true,
-  },
-];
+const JoinServerModal = ({ server, onClose, onSubmit }) => {
+  const [serverPassword, setserverPassword] = useState("");
+  const [error, setError] = useState("");
 
-const JoinServerModal = ({ serverName, onClose, onSubmit }) => {
-  const handleSubmit = async (values) => {
-    // 폼에서 입력받은 { password: "..." } 값을 부모의 API 호출 함수로 전달
-    await onSubmit(values.password);
+  if (!server) return null;
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError("");
+    try { await onSubmit(server.isPrivate ? serverPassword : null); } 
+    catch (err) { setError(err.message || "비밀번호가 올바르지 않습니다."); }
   };
 
+  // 이미지에 있던 규칙 리스트 예시 (데이터에 없으면 기본값으로 표시)
+  const rules = server?.rules || [];
+
   return (
-    <FormModal
-      open
-      title={`'${serverName}' 서버 참가`}
-      description="이 서버는 비공개입니다. 접근을 위해 비밀번호를 입력해주세요."
-      fields={joinFields}
-      submitLabel="입장하기"
-      cancelLabel="취소"
-      onClose={onClose}
-      onSubmit={handleSubmit}
-    />
+    <div className="join-modal-overlay">
+      <div className="join-modal-content">
+        <button className="close-x" onClick={onClose}>&times;</button>
+        
+        {server.isPrivate && <div className="private-badge">Private</div>}
+        
+        <header className="modal-header">
+          <p className="server-desc-small">{server?.description}</p>
+          <h2 className="server-name-large">{server?.serverName || server?.title}</h2>
+        </header>
+
+        <div className="server-stats">
+          <div className="host-profile">
+            <div className="avatar-circle" />
+            <span><strong>{server?.hostName || "관리자"}</strong> 호스트님</span>
+          </div>
+          <div className="member-status">
+            <span className="dot">●</span> 멤버 {server?.currentCount || 0} / {server?.maxCapacity || 12} 명
+          </div>
+        </div>
+
+        <div className="rules-box">
+          <p className="rules-title">이 규칙은 지켜주세요-!</p>
+          <ul className="rules-list">
+            {rules.length > 0 ? (
+              rules.map((rule, idx) => (
+              <li key={idx}>
+                <span className="rule-icon">{rule.icon}</span>
+                {rule.text}
+              </li>
+              ))
+            ) : (
+            <p style={{ fontSize: '12px', color: '#666' }}>설정된 규칙이 없습니다.</p>
+            )}
+          </ul>
+        </div>
+
+        <form onSubmit={handleSubmit} className="join-input-section">
+          {server.isPrivate && (
+            <div className="password-field">
+              <label className="input-label">비밀번호</label>
+              <input
+                type="password"
+                className={`pw-input ${error ? "input-error" : ""}`}
+                placeholder="********"
+                value={serverPassword}
+                onChange={(e) => setserverPassword(e.target.value)}
+                required
+              />
+              {error && <p className="error-msg-text">{error}</p>}
+            </div>
+          )}
+          
+          <div className="button-group">
+            <button type="button" className="btn-cancel" onClick={onClose}>취소</button>
+            <button type="submit" className="btn-enter">접속하기</button>
+          </div>
+        </form>
+      </div>
+    </div>
   );
 };
 

--- a/frontend/src/components/layout/ServerContextMenu.css
+++ b/frontend/src/components/layout/ServerContextMenu.css
@@ -1,0 +1,87 @@
+.context-menu-backdrop {
+  position: fixed;
+  top: 0; left: 0;
+  width: 100vw; height: 100vh;
+  z-index: 999;
+  background: transparent;
+}
+
+.server-context-menu {
+  position: fixed;
+  background-color: #111214; /* 더 깊은 다크 톤 */
+  border-radius: 8px; /* 조금 더 둥글게 */
+  padding: 8px;
+  min-width: 220px;
+  /* 디스코드 특유의 입체감 있는 그림자 */
+  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.4), 0 0 0 1px rgba(0, 0, 0, 0.2);
+  z-index: 1000;
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.05); /* 미세한 테두리로 경계 구분 */
+}
+
+.context-menu-header {
+  padding: 12px 12px 8px 12px;
+  font-size: 11px;
+  font-weight: 700;
+  color: #949ba4; /* 보조 텍스트 색상 */
+  text-transform: uppercase; /* 대문자로 강조 */
+  letter-spacing: 0.02em;
+}
+
+.context-menu-divider {
+  height: 1px;
+  background: rgba(78, 80, 88, 0.48); /* 은은한 구분선 */
+  margin: 6px 4px;
+}
+
+.context-menu-item {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between; /* 아이콘과 텍스트 간격 조정 */
+  padding: 10px 12px;
+  font-size: 14px;
+  font-weight: 500;
+  color: #dbdee1;
+  background: none;
+  border: none;
+  border-radius: 4px; /* 아이템 호버 시 둥근 사각형 */
+  cursor: pointer;
+  transition: background-color 0.15s ease, color 0.15s ease;
+  margin-bottom: 2px;
+}
+
+.context-menu-item:last-child {
+  margin-bottom: 0;
+}
+
+.context-menu-item:hover {
+  background-color: #4752c4; /* 디스코드 시그니처 블루 */
+  color: #ffffff;
+}
+
+/* 삭제 버튼 전용 스타일 (Danger) */
+.context-menu-item.danger {
+  color: #f23f43; /* 밝은 빨간색 */
+}
+
+.context-menu-item.danger:hover {
+  background-color: #da373c; /* 호버 시 빨간 배경 */
+  color: #ffffff;
+}
+
+.menu-icon {
+  font-size: 16px;
+  margin-right: 12px;
+  opacity: 0.8;
+}
+
+/* 메뉴가 나타날 때의 부드러운 애니메이션 */
+@keyframes contextMenuFadeIn {
+  from { opacity: 0; transform: translateY(-5px) scale(0.98); }
+  to { opacity: 1; transform: translateY(0) scale(1); }
+}
+
+.server-context-menu {
+  animation: contextMenuFadeIn 0.1s ease-out;
+}

--- a/frontend/src/components/layout/ServerContextMenu.js
+++ b/frontend/src/components/layout/ServerContextMenu.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import './ServerContextMenu.css';
+
+const ServerContextMenu = ({ x, y, server, isHost, onClose, onSettings, onDelete, onLeave }) => {
+  return (
+    <>
+      <div className="context-menu-backdrop" onClick={onClose} />
+      <div className="server-context-menu" style={{ top: y, left: x }}>
+        <div className="context-menu-header">{server.serverName}</div>
+        
+        {/* 호스트일 때만 '설정' 메뉴 노출 */}
+        {isHost && (
+          <button className="context-menu-item" onClick={() => onSettings(server)}>
+            <span className="menu-icon">⚙️</span> 서버 설정
+          </button>
+        )}
+
+        <div className="context-menu-divider" />
+
+        {/* 🔴 조건부 렌더링: 호스트면 삭제, 아니면 나가기 */}
+        {isHost ? (
+          <button className="context-menu-item danger" onClick={() => onDelete(server)}>
+            <span className="menu-icon">🗑️</span> 서버 삭제
+          </button>
+        ) : (
+          <button className="context-menu-item danger" onClick={() => onLeave(server)}>
+            <span className="menu-icon">🚪</span> 서버 나가기
+          </button>
+        )}
+      </div>
+    </>
+  );
+};
+
+export default ServerContextMenu;

--- a/frontend/src/components/layout/ServerSidebar.js
+++ b/frontend/src/components/layout/ServerSidebar.js
@@ -1,27 +1,24 @@
 import React, { useState, useRef, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { getServerPath, PATHS } from "../../constants/path";
-import { useAuth } from "../../contexts/AuthContext"; //
+import { useAuth } from "../../contexts/AuthContext";
 import { useServers } from "../../contexts/ServerContext";
+import { deleteServer, leaveServer } from "../../lib/servers";
+import ServerContextMenu from "./ServerContextMenu";
+import FormModal from "../common/FormModal";
 import "./ServerSidebar.css";
-
-/**
- * @title 극좌측 서버 네비게이션 바
- * @param {string} activeView - 현재 활성화된 뷰 ('home', 'chat' 등)
- * @param {function} onServerClick - 서버 아이콘 클릭 시 실행할 함수
- * @param {function} onAddClick - + 버튼 클릭 시 실행할 함수
- * @param {function} onLogout - 로그아웃 함수
- */
+ 
 const ServerSidebar = ({ activeView, onServerClick, onAddClick, onLogout }) => {
   const navigate = useNavigate();
   const { user } = useAuth();
-  const { joinedServers, activeServerId } = useServers();
+  const { joinedServers, activeServerId, removeServerFromList } = useServers();
   const [isProfileMenuOpen, setIsProfileMenuOpen] = useState(false);
+  const [contextMenu, setContextMenu] = useState(null);
   const menuRef = useRef(null);
-
-  const initial = user?.nickname ? user.nickname.charAt(0) : "프"; // 닉네임의 첫 글자 추출 (정보가 없으면 '?' 표시)
-
-  // 메뉴 바깥 클릭 시 닫기
+  const initial = user?.nickname ? user.nickname.charAt(0) : "프";
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+  const [targetServer, setTargetServer] = useState(null);
+ 
   useEffect(() => {
     const handleClickOutside = (e) => {
       if (menuRef.current && !menuRef.current.contains(e.target)) {
@@ -31,86 +28,151 @@ const ServerSidebar = ({ activeView, onServerClick, onAddClick, onLogout }) => {
     document.addEventListener("mousedown", handleClickOutside);
     return () => document.removeEventListener("mousedown", handleClickOutside);
   }, []);
-
+ 
+  const handleContextMenu = (e, server) => {
+    e.preventDefault();
+    setContextMenu({ x: e.pageX, y: e.pageY, server });
+    setIsProfileMenuOpen(false);
+  };
+ 
+  const handleDeleteClick = (server) => {
+    setTargetServer(server);
+    setIsDeleteModalOpen(true);
+    setContextMenu(null);
+  };
+ 
+  const handleFinalDelete = async () => {
+    try {
+      await deleteServer(targetServer.serverId);
+      removeServerFromList(targetServer.serverId);
+      setIsDeleteModalOpen(false);
+      setTargetServer(null);
+      alert("서버가 성공적으로 삭제되었습니다.");
+      if (activeServerId === targetServer.serverId) navigate("/");
+    } catch (error) {
+      alert("삭제 실패: " + error.message);
+    }
+  };
+ 
+  const handleLeave = async (server) => {
+    const confirmLeave = window.confirm(`'${server.serverName}' 서버에서 나가시겠습니까?`);
+    if (confirmLeave) {
+      try {
+        await leaveServer(server.serverId);
+        removeServerFromList(server.serverId);
+        alert("서버에서 퇴장했습니다.");
+        if (activeServerId === server.serverId) navigate("/");
+      } catch (error) {
+        console.error("나가기 실패:", error);
+        alert(error.message || "서버에서 나가는 중 오류가 발생했습니다.");
+      }
+    }
+    setContextMenu(null);
+  };
+ 
   const handleLogout = () => {
     setIsProfileMenuOpen(false);
     if (onLogout) onLogout();
   };
-
+ 
   const handleProfileEdit = () => {
     setIsProfileMenuOpen(false);
     navigate(PATHS.profileEdit || "/profile/edit");
   };
-
+ 
   return (
-    <nav className="server-nav">
-      {joinedServers.map((server) => {
-        const serverName = server.serverName || server.title || "";
-        const serverInitial = serverName
-          ? serverName.trim().charAt(0).toUpperCase()
-          : "?";
-        const isActiveServer =
-          activeView === "chat" && server.serverId === activeServerId;
-
-        return (
-          <div
-            key={server.serverId}
-            className={`server-icon server-entry-icon ${isActiveServer ? "active-server" : ""}`}
-            onClick={() => navigate(getServerPath(server.serverId))}
-            title={serverName || "접속한 서버"}
-          >
-            {serverInitial}
-          </div>
-        );
-      })}
-
-      {/* 서버 추가 버튼 */}
-      <div
-        className="server-icon add-btn"
-        onClick={onAddClick}
-        title="서버 추가"
-      >
-        +
-      </div>
-
-      <div className="spacer"></div>
-
-      {/* 하단 프로필 아바타 + 팝업 메뉴 */}
-      <div className="profile-wrapper" ref={menuRef}>
-        {/* 설정 팝업 메뉴 */}
-        {isProfileMenuOpen && (
-          <div className="profile-popup">
-            <div className="profile-popup-title">
-              {user?.nickname || "사용자"}님
-            </div>
-            <div className="profile-popup-divider" />
-            <button className="profile-popup-item" onClick={handleProfileEdit}>
-              <span className="popup-icon">✏️</span>
-              프로필 편집
-              <span className="popup-arrow">›</span>
-            </button>
-            <div className="profile-popup-divider" />
-            <button
-              className="profile-popup-item danger"
-              onClick={handleLogout}
-            >
-              <span className="popup-icon">🚪</span>
-              로그아웃
-            </button>
-          </div>
-        )}
-
-        {/* 프로필 아바타 버튼 */}
-        <div
-          className="server-icon profile-icon"
-          onClick={() => setIsProfileMenuOpen((prev) => !prev)}
-          title={user?.nickname || "프로필"}
+    <>
+      {/* ✅ FormModal을 nav 밖으로 분리 → portal처럼 최상위에서 렌더링 */}
+      {isDeleteModalOpen && targetServer && (
+        <FormModal
+          open={isDeleteModalOpen}
+          title="서버 삭제"
+          onClose={() => {
+            setIsDeleteModalOpen(false);
+            setTargetServer(null);
+          }}
+          onSubmit={handleFinalDelete}
+          submitLabel="서버 삭제"
+          variant="danger"
         >
-          {initial}
+          <div className="delete-confirm-content">
+            <p style={{ color: "#dbdee1", lineHeight: "1.5" }}>
+              정말로 <strong>{targetServer.serverName}</strong> 서버를 삭제하시겠습니까?<br />
+              이 작업은 취소할 수 없으며, 모든 데이터가 영구적으로 삭제됩니다.
+            </p>
+          </div>
+        </FormModal>
+      )}
+ 
+      <nav className="server-nav">
+        {joinedServers.map((server) => {
+          const serverName = server.serverName || server.title || "";
+          const serverInitial = serverName ? serverName.trim().charAt(0).toUpperCase() : "?";
+          const isActiveServer = activeView === "chat" && server.serverId === activeServerId;
+ 
+          return (
+            <div
+              key={server.serverId}
+              className={`server-icon server-entry-icon ${isActiveServer ? "active-server" : ""}`}
+              onClick={() => navigate(getServerPath(server.serverId))}
+              onContextMenu={(e) => handleContextMenu(e, server)}
+              title={serverName || "접속한 서버"}
+            >
+              {serverInitial}
+            </div>
+          );
+        })}
+ 
+        <div className="server-icon add-btn" onClick={onAddClick} title="서버 추가">+</div>
+ 
+        <div className="spacer"></div>
+ 
+        {/* 컨텍스트 메뉴 */}
+        {contextMenu && (
+          <ServerContextMenu
+            x={contextMenu.x}
+            y={contextMenu.y}
+            server={contextMenu.server}
+            isHost={user?.userId === contextMenu.server.hostId}
+            onClose={() => setContextMenu(null)}
+            onDelete={handleDeleteClick}
+            onLeave={handleLeave}
+            onSettings={(server) => {
+              console.log("서버 설정 열기:", server.serverName);
+              setContextMenu(null);
+            }}
+          />
+        )}
+ 
+        {/* 하단 프로필 */}
+        <div className="profile-wrapper" ref={menuRef}>
+          {isProfileMenuOpen && (
+            <div className="profile-popup">
+              <div className="profile-popup-title">{user?.nickname || "사용자"}님</div>
+              <div className="profile-popup-divider" />
+              <button className="profile-popup-item" onClick={handleProfileEdit}>
+                <span className="popup-icon">✏️</span>
+                프로필 편집
+                <span className="popup-arrow">›</span>
+              </button>
+              <div className="profile-popup-divider" />
+              <button className="profile-popup-item danger" onClick={handleLogout}>
+                <span className="popup-icon">🚪</span>
+                로그아웃
+              </button>
+            </div>
+          )}
+          <div
+            className="server-icon profile-icon"
+            onClick={() => setIsProfileMenuOpen((prev) => !prev)}
+            title={user?.nickname || "프로필"}
+          >
+            {initial}
+          </div>
         </div>
-      </div>
-    </nav>
+      </nav>
+    </>
   );
 };
-
+ 
 export default ServerSidebar;

--- a/frontend/src/contexts/ServerContext.js
+++ b/frontend/src/contexts/ServerContext.js
@@ -19,6 +19,33 @@ export const ServerProvider = ({ children }) => {
   const { isLoggedIn } = useAuth();
   const [joinedServers, setJoinedServers] = useState([]);
   const [activeServerId, setActiveServerId] = useState(null);
+  const [exploreServers, setExploreServers] = useState([]);
+
+  // 서버 목록을 API로부터 가져오는 함수를 별도로 분리 (재사용 가능하게)
+  const refreshJoinedServers = useCallback(async () => {
+    try {
+      const data = await getMyServers();
+      const servers = Array.isArray(data?.items) ? data.items : [];
+      setJoinedServers(
+        servers.map((server) => ({
+          serverId: server.serverId || server.roomId,
+          serverName: server.serverName || server.roomName || server.title || "",
+        }))
+      );
+    } catch (error) {
+      console.error("내 서버 목록을 갱신하지 못했습니다.", error);
+    }
+  }, []);
+
+  // 리스트에서 특정 서버를 즉시 제거하는 함수 (삭제 성공 시 사용)
+  const removeServerFromList = useCallback((serverId) => {
+    setJoinedServers((prev) => prev.filter((s) => s.serverId !== serverId));
+    setExploreServers((prev) => prev.filter((s) => s.serverId !== serverId));
+  }, []);
+
+  const setPublicServers = useCallback((servers) => {
+    setExploreServers(servers);
+  }, []);
 
   // serverId 우선 사용, 기존 roomId 호환을 위해 fallback 처리
   // 백엔드 마이그레이션 완료 후에는 server.serverId만 사용하면 됨
@@ -44,10 +71,8 @@ export const ServerProvider = ({ children }) => {
   }, []);
 
   useEffect(() => {
-    if (!isLoggedIn) {
-      clearJoinedServers();
-      return;
-    }
+    if (isLoggedIn) { refreshJoinedServers(); }
+    else { clearJoinedServers(); }
 
     let isMounted = true;
 
@@ -76,12 +101,16 @@ export const ServerProvider = ({ children }) => {
   const value = useMemo(
     () => ({
       joinedServers,
+      exploreServers,
       activeServerId,
+      setExploreServers,
       setActiveServerId,
       upsertJoinedServer,
       clearJoinedServers,
+      refreshJoinedServers,
+      removeServerFromList,
     }),
-    [joinedServers, activeServerId, upsertJoinedServer, clearJoinedServers],
+    [joinedServers, activeServerId, upsertJoinedServer, clearJoinedServers, refreshJoinedServers, removeServerFromList],
   );
 
   return <ServerContext.Provider value={value}>{children}</ServerContext.Provider>;

--- a/frontend/src/contexts/ServerContext.js
+++ b/frontend/src/contexts/ServerContext.js
@@ -43,10 +43,6 @@ export const ServerProvider = ({ children }) => {
     setExploreServers((prev) => prev.filter((s) => s.serverId !== serverId));
   }, []);
 
-  const setPublicServers = useCallback((servers) => {
-    setExploreServers(servers);
-  }, []);
-
   // serverId 우선 사용, 기존 roomId 호환을 위해 fallback 처리
   // 백엔드 마이그레이션 완료 후에는 server.serverId만 사용하면 됨
   const upsertJoinedServer = useCallback((server) => {
@@ -96,7 +92,7 @@ export const ServerProvider = ({ children }) => {
       });
 
     return () => { isMounted = false; };
-  }, [isLoggedIn, clearJoinedServers]);
+  }, [isLoggedIn, clearJoinedServers, refreshJoinedServers]);
 
   const value = useMemo(
     () => ({
@@ -110,7 +106,7 @@ export const ServerProvider = ({ children }) => {
       refreshJoinedServers,
       removeServerFromList,
     }),
-    [joinedServers, activeServerId, upsertJoinedServer, clearJoinedServers, refreshJoinedServers, removeServerFromList],
+    [joinedServers, exploreServers, activeServerId, upsertJoinedServer, clearJoinedServers, refreshJoinedServers, removeServerFromList],
   );
 
   return <ServerContext.Provider value={value}>{children}</ServerContext.Provider>;

--- a/frontend/src/lib/servers.js
+++ b/frontend/src/lib/servers.js
@@ -32,12 +32,12 @@ export function getServerMessages(serverId) {
   });
 }
 
-export function joinServer(serverId, password) {
+export function joinServer(serverId, serverPassword) {
   const options = {
     method: "POST",
   };
-  if (password) {
-    options.body = JSON.stringify({ password });
+  if (serverPassword) {
+    options.body = JSON.stringify({ serverPassword });
   }
   return request(`${ENDPOINTS.servers.list}/${serverId}/join`, options);
 }
@@ -46,5 +46,17 @@ export function createChannel(serverId, payload) {
   return request(`${ENDPOINTS.servers.list}/${serverId}/channels`, {
     method: "POST",
     body: JSON.stringify(payload),
+  });
+}
+
+export function deleteServer(serverId) {
+  return request(`${ENDPOINTS.servers.list}/${serverId}`, {
+    method: "DELETE", // DELETE 메서드 사용
+  });
+}
+
+export function leaveServer(serverId) {
+  return request(`${ENDPOINTS.servers.list}/${serverId}/leave`, {
+    method: "POST",
   });
 }


### PR DESCRIPTION
## 📌 관련 이슈
#(이슈 번호)

## 🏷️ 작업 유형 (Type of Change)
- [x] ✨ 기능 추가 (Feature)
- [x] 🐛 버그 수정 (Fix)
- [x] 🎨 UI/UX 및 디자인 변경 (Design)
- [x] ♻️ 리팩토링 (Refactor)
- [ ] 📝 문서 작업 (Docs)

## 🚀 작업 내용
- **서버 권한별 관리 기능 구현**: 방장은 '서버 삭제', 일반 멤버는 '서버 나가기'가 노출되도록 컨텍스트 메뉴 분기 처리
- **서버 규칙(Rules) 시스템**: 서버 생성 시 규칙 입력 기능 및 가입 전 브리핑 카드 내 규칙 표시 로직 추가
- **실시간 UI 상태 동기화**: ServerContext를 활용하여 삭제/퇴장 시 사이드바와 홈 화면 카드가 새로고침 없이 즉시 갱신되도록 개선
- ** 커스텀 삭제 확인 모달**: 기존 window.confirm을 FormModal 기반의 전용 경고창으로 교체하여 디자인 일관성 확보

## ✅ 체크리스트
- [x] `README.md`에 명시된 코딩 컨벤션 및 커밋 메시지 규칙을 준수했습니다.
- [x] 관련 없는 코드나 불필요한 주석을 포함하지 않았습니다.
- [x] 작업할 브랜치(예: `dev`)의 최신 상태를 pull 받아 충돌이 없는 것을 확인했습니다.
- [x] (Backend) 람다 함수나 DB 스키마 변경 시 로컬/테스트 환경에서 검증을 완료했습니다.

## 💬 리뷰어에게
- 서버 사이드바에 있는 서버 아이콘 우클릭시 방장은 삭제, 일반 멤버는 나가기 화면이 나오는 모달 제작
- 서버 생성시 서버 규칙을 적을 수 있도록 하였습니다
- 서버 입장시 서버 규칙을 볼 수 있도록 하였습니다.