### PR TITLE
Refactor: Frontend server 용어 정리 및 공통 UI/모달 리팩터링

### DIFF
--- a/frontend/src/components/Auth/Auth.css
+++ b/frontend/src/components/Auth/Auth.css
@@ -9,6 +9,26 @@
   padding: 24px;
 }
 
+.auth-back-button {
+  position: absolute;
+  top: 32px;
+  left: 32px;
+  background: none;
+  border: none;
+  color: var(--text-secondary);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 14px;
+  font-weight: 600;
+  transition: color 0.2s;
+}
+
+.auth-back-button:hover {
+  color: var(--text-primary);
+}
+
 .auth-header {
   text-align: center;
   margin-bottom: 32px;

--- a/frontend/src/components/Auth/AuthShell.js
+++ b/frontend/src/components/Auth/AuthShell.js
@@ -1,0 +1,62 @@
+import React from "react";
+import { useNavigate } from "react-router-dom";
+import { PATHS } from "../../constants/path";
+import "./Auth.css";
+
+const TerminalIcon = () => (
+  <svg
+    className="terminal-icon"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <polyline points="4 17 10 11 4 5"></polyline>
+    <line x1="12" y1="19" x2="20" y2="19"></line>
+  </svg>
+);
+
+function AuthShell({ title, subtitle, footer, children }) {
+  const navigate = useNavigate();
+
+  return (
+    <div className="auth-container">
+      <button
+        type="button"
+        className="auth-back-button"
+        onClick={() => navigate(PATHS.onboarding)}
+      >
+        <svg
+          width="20"
+          height="20"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <line x1="19" y1="12" x2="5" y2="12"></line>
+          <polyline points="12 19 5 12 12 5"></polyline>
+        </svg>
+        뒤로가기
+      </button>
+
+      <div className="auth-header">
+        <div className="auth-icon-wrapper">
+          <TerminalIcon />
+        </div>
+        <h1 className="auth-title">{title}</h1>
+        <p className="auth-subtitle">{subtitle}</p>
+      </div>
+
+      <div className="auth-card">{children}</div>
+
+      {footer ? <div className="auth-footer">{footer}</div> : null}
+    </div>
+  );
+}
+
+export default AuthShell;

--- a/frontend/src/components/Auth/Login.js
+++ b/frontend/src/components/Auth/Login.js
@@ -3,22 +3,8 @@ import { Link, useLocation, useNavigate } from "react-router-dom";
 import { login as loginApi } from "../../lib/auth";
 import { useAuth } from "../../contexts/AuthContext";
 import { PATHS } from "../../constants/path";
+import AuthShell from "./AuthShell";
 import "./Auth.css";
-
-const TerminalIcon = () => (
-  <svg
-    className="terminal-icon"
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="2"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-  >
-    <polyline points="4 17 10 11 4 5"></polyline>
-    <line x1="12" y1="19" x2="20" y2="19"></line>
-  </svg>
-);
 
 const GoogleIcon = () => (
   <svg
@@ -83,56 +69,18 @@ const Login = () => {
   };
 
   return (
-    <div className="auth-container">
-      <button
-        onClick={() => navigate(PATHS.onboarding)}
-        style={{
-          position: "absolute",
-          top: "32px",
-          left: "32px",
-          background: "none",
-          border: "none",
-          color: "var(--text-secondary)",
-          cursor: "pointer",
-          display: "flex",
-          alignItems: "center",
-          gap: "8px",
-          fontSize: "14px",
-          fontWeight: 600,
-          transition: "color 0.2s",
-        }}
-        onMouseOver={(e) =>
-          (e.currentTarget.style.color = "var(--text-primary)")
-        }
-        onMouseOut={(e) =>
-          (e.currentTarget.style.color = "var(--text-secondary)")
-        }
-      >
-        <svg
-          width="20"
-          height="20"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        >
-          <line x1="19" y1="12" x2="5" y2="12"></line>
-          <polyline points="12 19 5 12 12 5"></polyline>
-        </svg>
-        뒤로가기
-      </button>
-
-      <div className="auth-header">
-        <div className="auth-icon-wrapper">
-          <TerminalIcon />
-        </div>
-        <h1 className="auth-title">다시 만나서 반가워요</h1>
-        <p className="auth-subtitle">계정에 로그인하여 학습을 이어가세요!</p>
-      </div>
-
-      <div className="auth-card">
+    <AuthShell
+      title="다시 만나서 반가워요"
+      subtitle="계정에 로그인하여 학습을 이어가세요!"
+      footer={
+        <>
+          아직 계정이 없으신가요?{" "}
+          <Link to={PATHS.register} className="auth-link">
+            회원가입
+          </Link>
+        </>
+      }
+    >
         <form onSubmit={handleLogin}>
           {successMessage && <p className="auth-success">{successMessage}</p>}
 
@@ -182,15 +130,7 @@ const Login = () => {
         <button type="button" className="btn-secondary">
           <GoogleIcon /> Google 계정으로 로그인
         </button>
-      </div>
-
-      <div className="auth-footer">
-        아직 계정이 없으신가요?{" "}
-        <Link to={PATHS.register} className="auth-link">
-          회원가입
-        </Link>
-      </div>
-    </div>
+    </AuthShell>
   );
 };
 

--- a/frontend/src/components/Auth/Register.js
+++ b/frontend/src/components/Auth/Register.js
@@ -2,22 +2,8 @@ import React, { useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { register as registerApi } from "../../lib/auth";
 import { PATHS } from "../../constants/path";
+import AuthShell from "./AuthShell";
 import "./Auth.css";
-
-const TerminalIcon = () => (
-  <svg
-    className="terminal-icon"
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="2"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-  >
-    <polyline points="4 17 10 11 4 5"></polyline>
-    <line x1="12" y1="19" x2="20" y2="19"></line>
-  </svg>
-);
 
 const Register = () => {
   const navigate = useNavigate();
@@ -55,56 +41,18 @@ const Register = () => {
   };
 
   return (
-    <div className="auth-container">
-      <button
-        onClick={() => navigate(PATHS.onboarding)}
-        style={{
-          position: "absolute",
-          top: "32px",
-          left: "32px",
-          background: "none",
-          border: "none",
-          color: "var(--text-secondary)",
-          cursor: "pointer",
-          display: "flex",
-          alignItems: "center",
-          gap: "8px",
-          fontSize: "14px",
-          fontWeight: 600,
-          transition: "color 0.2s",
-        }}
-        onMouseOver={(e) =>
-          (e.currentTarget.style.color = "var(--text-primary)")
-        }
-        onMouseOut={(e) =>
-          (e.currentTarget.style.color = "var(--text-secondary)")
-        }
-      >
-        <svg
-          width="20"
-          height="20"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        >
-          <line x1="19" y1="12" x2="5" y2="12"></line>
-          <polyline points="12 19 5 12 12 5"></polyline>
-        </svg>
-        뒤로가기
-      </button>
-
-      <div className="auth-header">
-        <div className="auth-icon-wrapper">
-          <TerminalIcon />
-        </div>
-        <h1 className="auth-title">새 계정 만들기</h1>
-        <p className="auth-subtitle">아래에 정보를 입력하여 시작하세요.</p>
-      </div>
-
-      <div className="auth-card">
+    <AuthShell
+      title="새 계정 만들기"
+      subtitle="아래에 정보를 입력하여 시작하세요."
+      footer={
+        <>
+          이미 계정이 있으신가요?{" "}
+          <Link to={PATHS.login} className="auth-link">
+            로그인
+          </Link>
+        </>
+      }
+    >
         <form onSubmit={handleRegister}>
           <div className="form-group">
             <label className="form-label" htmlFor="email">
@@ -157,15 +105,7 @@ const Register = () => {
             {loading ? "가입 중..." : "계속하기"}
           </button>
         </form>
-      </div>
-
-      <div className="auth-footer">
-        이미 계정이 있으신가요?{" "}
-        <Link to={PATHS.login} className="auth-link">
-          로그인
-        </Link>
-      </div>
-    </div>
+    </AuthShell>
   );
 };
 

--- a/frontend/src/components/Chat/ChatLayout.js
+++ b/frontend/src/components/Chat/ChatLayout.js
@@ -25,6 +25,7 @@ import {
   buildChannelContextMenuItems,
   buildServerContextMenuItems,
 } from "./utils/contextMenuFactories";
+import { getServerId, getServerName } from "../../lib/serverEntity";
 
 const ChatLayout = () => {
   const { serverId } = useParams();
@@ -93,8 +94,7 @@ const ChatLayout = () => {
     () =>
       openSettingsModal({
         type: "server",
-        entityName:
-          currentServer?.roomName || currentServer?.serverName || currentServer?.title || "현재 서버",
+        entityName: getServerName(currentServer),
       }),
     [currentServer, openSettingsModal],
   );
@@ -185,20 +185,20 @@ const ChatLayout = () => {
         contextMenuType={contextMenu?.type}
         contextMenuTargetId={contextMenu?.targetId}
         onServerContextMenu={(event, server) => {
-          const sid = server.serverId || server.roomId;
+          const sid = getServerId(server);
           const resolvedServer =
-            (currentServer?.serverId || currentServer?.roomId) === sid ? currentServer : server;
+            getServerId(currentServer) === sid ? currentServer : server;
           openContextMenu(event, {
             type: "server",
             targetId: sid,
-            title: resolvedServer.roomName || resolvedServer.serverName || resolvedServer.title || "현재 서버",
+            title: getServerName(resolvedServer),
             items: serverMenuItems,
           });
         }}
       />
 
       <SidebarLeft
-        serverName={currentServer?.serverName || currentServer?.roomName || currentServer?.title || "로딩 중..."}
+        serverName={getServerName(currentServer, "로딩 중...")}
         channels={currentServer?.channels || []}
         activeChannel={activeChannel}
         onChannelClick={setActiveChannel}
@@ -211,7 +211,7 @@ const ChatLayout = () => {
           openContextMenu(event, {
             type: "server",
             targetId: serverId,
-            title: currentServer?.roomName || currentServer?.serverName || currentServer?.title || "현재 서버",
+            title: getServerName(currentServer),
             items: serverMenuItems,
           })
         }
@@ -247,7 +247,7 @@ const ChatLayout = () => {
 
       <CreateChannelModal
         open={isChannelModalOpen}
-        serverName={currentServer?.serverName || currentServer?.roomName || currentServer?.title || "현재 서버"}
+        serverName={getServerName(currentServer)}
         onClose={() => setIsChannelModalOpen(false)}
         onSubmit={handleCreateChannel}
       />

--- a/frontend/src/components/Chat/SidebarLeft.js
+++ b/frontend/src/components/Chat/SidebarLeft.js
@@ -14,8 +14,8 @@ function handleRightClick(event, callback, payload) {
  * @param {string} activeChannel - 현재 활성화된 채널 ID
  * @param {function} onChannelClick - 채널 클릭 시 실행 (채널 ID 전달)
  * @param {function} onAddChannelClick - 채널 추가 버튼 클릭 시 실행
- * @param {Array} members - 서버 멤버 목록 ({userId, nickname, role} 형태, getRoomDetail 응답에서 전달)
- * @param {string} hostId - 방장 userId (방장 태그 표시용)
+ * @param {Array} members - 서버 멤버 목록 ({userId, nickname, role} 형태)
+ * @param {string} hostId - 서버 방장 userId (방장 태그 표시용)
  */
 const SidebarLeft = ({
   serverName,

--- a/frontend/src/components/Chat/hooks/useChatServerData.js
+++ b/frontend/src/components/Chat/hooks/useChatServerData.js
@@ -10,17 +10,19 @@ import {
   deleteServer,
   leaveServer as leaveServerApi,
 } from "../../../lib/servers";
+import { normalizeServer } from "../../../lib/serverEntity";
 
 function normalizeServerWithMessages(serverData, messagesData) {
+  const normalizedServer = normalizeServer(serverData);
   const messages = Array.isArray(messagesData)
     ? messagesData
     : messagesData?.items || [];
-  const channels = serverData?.channels || [
+  const channels = normalizedServer.channels || [
     { id: "ch-general", name: "일반", label: "일반", isDefault: true },
   ];
 
   return {
-    ...serverData,
+    ...normalizedServer,
     channels: channels.map((channel, index) => ({
       ...channel,
       label: channel.label || channel.name,
@@ -46,8 +48,13 @@ function useChatServerData({
     setLoading(true);
     setActiveServerId(serverId);
 
-    Promise.all([getServerDetail(serverId), getServerMessages(serverId)])
-      .then(([serverData, messagesData]) => {
+    getServerDetail(serverId)
+      .then(async (serverData) => {
+        const messagesData = await getServerMessages(serverId).catch((error) => {
+          console.error("메시지 정보를 가져오는 중 오류 발생:", error);
+          return [];
+        });
+
         if (!isMounted) {
           return;
         }
@@ -57,7 +64,7 @@ function useChatServerData({
           messagesData,
         );
 
-        upsertJoinedServer(serverData);
+        upsertJoinedServer(normalizedServer);
         setCurrentServer(normalizedServer);
         setActiveChannel(
           normalizedServer.channels[0]?.id || normalizedServer.channels[0]?.chId || "",
@@ -79,12 +86,14 @@ function useChatServerData({
   }, [serverId, setActiveServerId, upsertJoinedServer]);
 
   const applyServerUpdate = (updatedServer) => {
+    const normalizedServer = normalizeServer(updatedServer);
+
     setCurrentServer((prev) => ({
       ...prev,
-      ...updatedServer,
-      channels: updatedServer.channels || prev?.channels || [],
+      ...normalizedServer,
+      channels: normalizedServer.channels || prev?.channels || [],
     }));
-    upsertJoinedServer(updatedServer);
+    upsertJoinedServer(normalizedServer);
   };
 
   const createChannelInServer = async (values) => {
@@ -122,13 +131,13 @@ function useChatServerData({
     }
 
     const updatedServer = await updateServer(serverId, {
-      roomName: trimmedName,
+      serverName: trimmedName,
       description: values.description?.trim() || "",
       maxCapacity: Number(values.maxParticipants),
       isPrivate: values.privacy === "Private",
     });
 
-    applyServerUpdate(updatedServer.room || updatedServer);
+    applyServerUpdate(updatedServer);
   };
 
   const saveChannelSettings = async (channel, values) => {

--- a/frontend/src/components/Servers/ExploreServers.js
+++ b/frontend/src/components/Servers/ExploreServers.js
@@ -18,9 +18,15 @@ import {
 } from "../common/entityFormConfig";
 import { buildServerContextMenuItems } from "../Chat/utils/contextMenuFactories";
 import JoinServerModal from "./JoinServerModal";
+import {
+  getServerId,
+  getServerName,
+  normalizeServer,
+  normalizeServers,
+} from "../../lib/serverEntity";
 
 const ServerCard = ({ server, onJoin }) => {
-  const name = server.serverName || server.title || "제목 없음";
+  const name = getServerName(server, "제목 없음");
   const description = server.description;
   const currentMembers = Number(server.currentCount) || 0;
   const maxMembers = server.maxCapacity || 12;
@@ -130,7 +136,7 @@ const ExploreServers = () => {
   useEffect(() => {
     setActiveServerId(null);
     getServers()
-      .then((data) => setServers(data.items || []))
+      .then((data) => setServers(normalizeServers(data.items || [])))
       .catch((err) => {
         console.error("데이터 로드 실패!", err);
         setServers([]);
@@ -147,10 +153,10 @@ const ExploreServers = () => {
   });
 
   const executeJoin = async (server, password = null) => {
-    const sid = server.serverId || server.roomId;
+    const sid = getServerId(server);
     try {
       await joinServer(sid, password);
-      upsertJoinedServer(server);
+      upsertJoinedServer(normalizeServer(server));
       navigate(getServerPath(sid));
     } catch (error) {
       console.error("서버 참여 실패:", error);
@@ -175,27 +181,26 @@ const ExploreServers = () => {
   };
 
   const resolveServerForMenu = (server) => {
-    const sid = server.serverId || server.roomId;
-    return servers.find((item) => (item.serverId || item.roomId) === sid) || server;
+    const sid = getServerId(server);
+    return servers.find((item) => getServerId(item) === sid) || server;
   };
 
   const handleOpenServerMenu = (event, server) => {
     const resolvedServer = resolveServerForMenu(server);
-    const sid = resolvedServer.serverId || resolvedServer.roomId;
+    const sid = getServerId(resolvedServer);
     const isHost = user?.userId === resolvedServer.hostId;
 
     openContextMenu(event, {
       type: "server",
       targetId: sid,
-      title: resolvedServer.roomName || resolvedServer.serverName || resolvedServer.title || "현재 서버",
+      title: getServerName(resolvedServer),
       items: buildServerContextMenuItems({
         canDelete: isHost,
         onOpenSettings: () =>
           openSettingsModal({
             type: "server",
             server: resolvedServer,
-            entityName:
-              resolvedServer.roomName || resolvedServer.serverName || resolvedServer.title || "현재 서버",
+            entityName: getServerName(resolvedServer),
           }),
         onOpenDeleteConfirm: () =>
           openConfirmModal({
@@ -204,7 +209,7 @@ const ExploreServers = () => {
             onConfirm: async () => {
               await deleteServer(sid);
               setServers((prev) =>
-                prev.filter((item) => (item.serverId || item.roomId) !== sid),
+                prev.filter((item) => getServerId(item) !== sid),
               );
               removeJoinedServer(sid);
               closeConfirmModal();
@@ -225,7 +230,7 @@ const ExploreServers = () => {
   };
 
   const handleServerSettingsSubmit = async (values) => {
-    const sid = settingsModal?.server?.serverId || settingsModal?.server?.roomId;
+    const sid = getServerId(settingsModal?.server);
     const trimmedName = values.serverName.trim();
 
     if (!trimmedName) {
@@ -233,16 +238,16 @@ const ExploreServers = () => {
     }
 
     const updatedServer = await updateServer(sid, {
-      roomName: trimmedName,
+      serverName: trimmedName,
       description: values.description?.trim() || "",
       maxCapacity: Number(values.maxParticipants),
       isPrivate: values.privacy === "Private",
     });
-    const resolvedServer = updatedServer.room || updatedServer;
+    const resolvedServer = normalizeServer(updatedServer);
 
     setServers((prev) =>
       prev.map((server) =>
-        (server.serverId || server.roomId) === sid ? resolvedServer : server,
+        getServerId(server) === sid ? resolvedServer : server,
       ),
     );
     closeSettingsModal();
@@ -296,12 +301,12 @@ const ExploreServers = () => {
         </div>
 
         <div className="servers-grid">
-          {filteredServers.map((server) => (
-            <ServerCard
-              key={server.serverId || server.roomId}
-              server={server}
-              onJoin={handleJoinClick}
-            />
+            {filteredServers.map((server) => (
+              <ServerCard
+                key={getServerId(server)}
+                server={server}
+                onJoin={handleJoinClick}
+              />
           ))}
 
           <div

--- a/frontend/src/components/Servers/JoinServerModal.js
+++ b/frontend/src/components/Servers/JoinServerModal.js
@@ -1,8 +1,9 @@
 import React, { useState } from "react";
-import "./JoinServerModal.css"
+import { getServerHostName, getServerName } from "../../lib/serverEntity";
+import "./JoinServerModal.css";
 
 const JoinServerModal = ({ server, onClose, onSubmit }) => {
-  const [serverPassword, setserverPassword] = useState("");
+  const [serverPassword, setServerPassword] = useState("");
   const [error, setError] = useState("");
 
   if (!server) return null;
@@ -10,7 +11,9 @@ const JoinServerModal = ({ server, onClose, onSubmit }) => {
   const handleSubmit = async (e) => {
     e.preventDefault();
     setError("");
-    try { await onSubmit(server.isPrivate ? serverPassword : null); } 
+    try {
+      await onSubmit(server.isPrivate ? serverPassword : null);
+    }
     catch (err) { setError(err.message || "비밀번호가 올바르지 않습니다."); }
   };
 
@@ -26,13 +29,13 @@ const JoinServerModal = ({ server, onClose, onSubmit }) => {
         
         <header className="modal-header">
           <p className="server-desc-small">{server?.description}</p>
-          <h2 className="server-name-large">{server?.serverName || server?.title}</h2>
+          <h2 className="server-name-large">{getServerName(server)}</h2>
         </header>
 
         <div className="server-stats">
           <div className="host-profile">
             <div className="avatar-circle" />
-            <span><strong>{server?.hostName || "관리자"}</strong> 호스트님</span>
+            <span><strong>{getServerHostName(server)}</strong> 호스트님</span>
           </div>
           <div className="member-status">
             <span className="dot">●</span> 멤버 {server?.currentCount || 0} / {server?.maxCapacity || 12} 명
@@ -64,7 +67,7 @@ const JoinServerModal = ({ server, onClose, onSubmit }) => {
                 className={`pw-input ${error ? "input-error" : ""}`}
                 placeholder="********"
                 value={serverPassword}
-                onChange={(e) => setserverPassword(e.target.value)}
+                onChange={(e) => setServerPassword(e.target.value)}
                 required
               />
               {error && <p className="error-msg-text">{error}</p>}

--- a/frontend/src/components/common/FormModal.css
+++ b/frontend/src/components/common/FormModal.css
@@ -10,11 +10,13 @@
     radial-gradient(circle at center, rgba(0, 255, 102, 0.08), transparent 42%),
     rgba(4, 5, 7, 0.82);
   backdrop-filter: blur(10px);
+  overflow-y: auto;
 }
 
 .form-modal {
   position: relative;
   width: min(100%, 760px);
+  max-height: min(calc(100vh - 48px), 920px);
   border-radius: 24px;
   border: 1px solid rgba(0, 255, 102, 0.35);
   background:
@@ -24,6 +26,7 @@
     0 24px 90px rgba(0, 0, 0, 0.55),
     0 0 40px rgba(0, 255, 102, 0.12);
   animation: form-modal-fade-in 0.2s ease-out;
+  overflow: hidden;
 }
 
 @keyframes form-modal-fade-in {
@@ -88,6 +91,8 @@
 
 .form-modal__form {
   padding: 0 44px 34px;
+  max-height: calc(min(calc(100vh - 48px), 920px) - 120px);
+  overflow-y: auto;
 }
 
 .form-modal__grid {
@@ -231,12 +236,13 @@
 
 .form-modal__footer {
   display: flex;
-  justify-content: space-between;
+  justify-content: flex-end;
   align-items: center;
   gap: 14px;
   border-top: 1px solid rgba(255, 255, 255, 0.06);
   margin-top: 20px;
   padding-top: 22px;
+  flex-wrap: wrap;
 }
 
 .form-modal__error {
@@ -244,7 +250,18 @@
   color: #ff7b7b;
   font-size: 13px;
   line-height: 1.5;
-  flex: 1;
+  flex: 1 0 100%;
+}
+
+.form-modal__error-spacer {
+  flex: 1 0 100%;
+}
+
+.form-modal__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+  margin-left: auto;
 }
 
 .form-modal__button {
@@ -292,13 +309,25 @@
     padding-right: 24px;
   }
 
+  .form-modal {
+    max-height: calc(100vh - 24px);
+  }
+
+  .form-modal__form {
+    max-height: calc(100vh - 144px);
+  }
+
   .form-modal__group--half {
     width: 100%;
   }
 
   .form-modal__footer {
-    flex-direction: column-reverse;
     align-items: stretch;
+  }
+
+  .form-modal__actions {
+    width: 100%;
+    flex-direction: column-reverse;
   }
 
   .form-modal__button {

--- a/frontend/src/components/common/FormModal.js
+++ b/frontend/src/components/common/FormModal.js
@@ -237,22 +237,24 @@ function FormModal({
             {submitError ? (
               <p className="form-modal__error">{submitError}</p>
             ) : (
-              <span />
+              <span className="form-modal__error-spacer" />
             )}
-            <button
-              type="button"
-              className="form-modal__button form-modal__button--ghost"
-              onClick={onClose}
-            >
-              {cancelLabel}
-            </button>
-            <button
-              type="submit"
-              className="form-modal__button form-modal__button--primary"
-              disabled={isSubmitting}
-            >
-              {isSubmitting ? "저장 중..." : submitLabel}
-            </button>
+            <div className="form-modal__actions">
+              <button
+                type="button"
+                className="form-modal__button form-modal__button--ghost"
+                onClick={onClose}
+              >
+                {cancelLabel}
+              </button>
+              <button
+                type="submit"
+                className="form-modal__button form-modal__button--primary"
+                disabled={isSubmitting}
+              >
+                {isSubmitting ? "저장 중..." : submitLabel}
+              </button>
+            </div>
           </div>
         </form>
       </div>

--- a/frontend/src/components/common/entityFormConfig.js
+++ b/frontend/src/components/common/entityFormConfig.js
@@ -92,7 +92,7 @@ export function createChannelFields(defaultValues = {}) {
 
 export function createServerDefaultValues(server = {}) {
   return {
-    serverName: server.roomName || server.title || "",
+    serverName: server.serverName || server.title || "",
     description: server.description || "",
     privacy: server.isPrivate ? "Private" : "Public",
     maxParticipants: Number(server.maxCapacity) || 12,

--- a/frontend/src/components/layout/ServerSidebar.js
+++ b/frontend/src/components/layout/ServerSidebar.js
@@ -3,6 +3,7 @@ import { useNavigate } from "react-router-dom";
 import { getServerPath, PATHS } from "../../constants/path";
 import { useAuth } from "../../contexts/AuthContext";
 import { useServers } from "../../contexts/ServerContext";
+import { getServerId, getServerName } from "../../lib/serverEntity";
 import "./ServerSidebar.css";
 
 function handleRightClick(event, callback, payload) {
@@ -58,8 +59,8 @@ const ServerSidebar = ({
   return (
     <nav className="server-nav">
       {joinedServers.map((server) => {
-        const sid = server.serverId || server.roomId;
-        const serverName = server.serverName || server.title || "";
+        const sid = getServerId(server);
+        const serverName = getServerName(server, "");
         const serverInitial = serverName
           ? serverName.trim().charAt(0).toUpperCase()
           : "?";

--- a/frontend/src/constants/path.js
+++ b/frontend/src/constants/path.js
@@ -1,6 +1,6 @@
 /**
  * @description 앱 라우팅 경로 상수 및 동적 경로 생성 유틸
- * @modified Room→Server 마이그레이션으로 /rooms → /servers 경로 변경
+ * @modified Server 경로 기준으로 /servers 라우팅 사용
  */
 
 export const PATHS = {

--- a/frontend/src/contexts/ServerContext.js
+++ b/frontend/src/contexts/ServerContext.js
@@ -1,6 +1,7 @@
 import React, { createContext, useContext, useState, useEffect, useMemo, useCallback } from "react";
 import { getMyServers } from "../lib/servers";
 import { useAuth } from "./AuthContext";
+import { getServerId, normalizeServer, normalizeServers } from "../lib/serverEntity";
 
 const ServerContext = createContext();
 
@@ -13,24 +14,29 @@ export const ServerProvider = ({ children }) => {
   const refreshJoinedServers = useCallback(async () => {
     try {
       const data = await getMyServers();
-      setJoinedServers(data.items || []);
+      setJoinedServers(normalizeServers(data.items || []));
     } catch (error) {
       console.error("Failed to refresh joined servers:", error);
     }
   }, []);
 
   const upsertJoinedServer = useCallback((server) => {
+    const normalizedServer = normalizeServer(server);
+
     setJoinedServers((prev) => {
-      const exists = prev.find((s) => (s.serverId || s.roomId) === (server.serverId || server.roomId));
+      const serverId = getServerId(normalizedServer);
+      const exists = prev.find((s) => getServerId(s) === serverId);
+
       if (exists) {
-        return prev.map((s) => ((s.serverId || s.roomId) === (server.serverId || server.roomId) ? { ...s, ...server } : s));
+        return prev.map((s) => (getServerId(s) === serverId ? { ...s, ...normalizedServer } : s));
       }
-      return [...prev, server];
+
+      return [...prev, normalizedServer];
     });
   }, []);
 
   const removeJoinedServer = useCallback((serverId) => {
-    setJoinedServers((prev) => prev.filter((s) => (s.serverId || s.roomId) !== serverId));
+    setJoinedServers((prev) => prev.filter((s) => getServerId(s) !== serverId));
   }, []);
 
   const removeServerFromList = useCallback((serverId) => {
@@ -51,7 +57,9 @@ export const ServerProvider = ({ children }) => {
 
     getMyServers()
       .then((data) => {
-        if (isMounted) setJoinedServers(data.items || []);
+        if (isMounted) {
+          setJoinedServers(normalizeServers(data.items || []));
+        }
       })
       .catch((err) => {
         console.error("Failed to load joined servers:", err);

--- a/frontend/src/lib/serverEntity.js
+++ b/frontend/src/lib/serverEntity.js
@@ -1,0 +1,24 @@
+export function getServerId(server) {
+  return server?.serverId || "";
+}
+
+export function getServerName(server, fallback = "현재 서버") {
+  return server?.serverName || server?.title || fallback;
+}
+
+export function getServerHostName(server, fallback = "관리자") {
+  return server?.hostNickname || fallback;
+}
+
+export function normalizeServer(server = {}) {
+  return {
+    ...server,
+    serverId: getServerId(server),
+    serverName: getServerName(server, ""),
+    hostNickname: getServerHostName(server, ""),
+  };
+}
+
+export function normalizeServers(servers = []) {
+  return servers.map((server) => normalizeServer(server));
+}

--- a/frontend/src/lib/servers.js
+++ b/frontend/src/lib/servers.js
@@ -56,7 +56,7 @@ export function joinServer(serverId, password) {
     method: "POST",
   };
   if (password) {
-    options.body = JSON.stringify({ password });
+    options.body = JSON.stringify({ serverPassword: password });
   }
   return request(`${ENDPOINTS.servers.list}/${serverId}/join`, options);
 }


### PR DESCRIPTION
## 📌 관련 이슈
#(이슈 번호)

## 🏷️ 작업 유형 (Type of Change)
- [ ] ✨ 기능 추가 (Feature)
- [x] 🐛 버그 수정 (Fix)
- [x] 🎨 UI/UX 및 디자인 변경 (Design)
- [x] ♻️ 리팩토링 (Refactor)
- [ ] 📝 문서 작업 (Docs)

## 🚀 작업 내용
- 프론트엔드 전반에 남아 있던 `roomId`, `roomName`, `updatedServer.room` 등 `room` 기반 참조를 제거하고 `server` 기준으로 통일했습니다.
- `serverId`, `serverName`, `hostNickname` 해석을 공통 유틸로 분리해 서버 목록, 채팅 화면, 전역 상태에서 동일한 방식으로 서버 데이터를 사용하도록 정리했습니다.
- 비공개 서버 입장 요청 payload를 백엔드 계약에 맞게 `serverPassword`로 수정했습니다.
- 로그인/회원가입 화면의 중복 레이아웃을 `AuthShell` 공통 컴포넌트로 추출해 출력은 유지하면서 중복 선언을 제거했습니다.
- 공통 `FormModal`을 개선해 서버 생성 모달에서 내부 스크롤이 가능하도록 수정했습니다.
- 모달 하단 버튼 영역을 정리해 `취소` 버튼과 확인 버튼이 우측 하단에 자연스럽게 정렬되도록 수정했습니다.
- 채팅 화면 진입 시 서버 상세 조회와 메시지 조회를 한 번에 실패 처리하던 구조를 완화해, 메시지 조회 실패가 서버 입장 실패로 이어지지 않도록 수정했습니다.
- 메시지 API 또는 `Messages` 테이블 상태와 무관하게 서버 상세 정보만 정상이라면 사이드바의 서버 아이콘으로 진입할 수 있도록 안정성을 보완했습니다.

## ✅ 체크리스트
- [ ] `README.md`에 명시된 코딩 컨벤션 및 커밋 메시지 규칙을 준수했습니다.
- [x] 관련 없는 코드나 불필요한 주석을 포함하지 않았습니다.
- [x] 작업할 브랜치(예: `dev`)의 최신 상태를 pull 받아 충돌이 없는 것을 확인했습니다.
- [ ] (Backend) 람다 함수나 DB 스키마 변경 시 로컬/테스트 환경에서 검증을 완료했습니다.

## 💬 리뷰어에게
- 이번 PR은 프론트엔드만 수정했고 백엔드는 변경하지 않았습니다.
- 다만 확인 결과, 백엔드에는 `PUT /servers/{serverId}` 및 채널 수정용 `PUT` 라우트가 없어 서버/채널 설정 저장은 현재 프론트만으로 완전히 동작하지 않습니다.
- 로컬 환경에서는 DynamoDB 테이블이 자동 생성되지 않으므로, LocalStack 실행 후 `backend/infra/createTable.js`를 별도로 실행해야 합니다.
- 프론트는 `npm run build` 기준으로 검증 완료했습니다.
