### PR TITLE
Feat: 파일 업로드 검증 강화 + OG 이미지 S3 캐싱

### DIFF
--- a/backend/src/resources/getUploadUrl.js
+++ b/backend/src/resources/getUploadUrl.js
@@ -2,12 +2,65 @@ const { S3Client, PutObjectCommand } = require("@aws-sdk/client-s3");
 const { getSignedUrl } = require("@aws-sdk/s3-request-presigner");
 const { v4: uuidv4 } = require("uuid");
 
-// S3 클라이언트 초기화 (Lambda 실행 역할의 권한을 자동 사용함)
 const s3Client = new S3Client({ region: process.env.AWS_REGION || "us-east-1" });
+
+// ── 허용 파일 타입 정의 ──────────────────────────────────
+const ALLOWED_TYPES = {
+  // 이미지
+  'image/jpeg': 'jpg',
+  'image/png': 'png',
+  'image/gif': 'gif',
+  'image/webp': 'webp',
+  'image/svg+xml': 'svg',
+  'image/bmp': 'bmp',
+  'image/tiff': 'tiff',
+  // 문서
+  'application/pdf': 'pdf',
+  'application/msword': 'doc',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document': 'docx',
+  'application/vnd.ms-excel': 'xls',
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': 'xlsx',
+  'application/vnd.ms-powerpoint': 'ppt',
+  'application/vnd.openxmlformats-officedocument.presentationml.presentation': 'pptx',
+  'application/vnd.hancom.hwp': 'hwp',
+  'application/haansofthwp': 'hwp',
+  'application/x-hwp': 'hwp',
+  // 텍스트/코드
+  'text/plain': 'txt',
+  'text/csv': 'csv',
+  'text/html': 'html',
+  'text/markdown': 'md',
+  'application/json': 'json',
+  'application/xml': 'xml',
+  'text/xml': 'xml',
+  // 압축
+  'application/zip': 'zip',
+  'application/x-zip-compressed': 'zip',
+  'application/gzip': 'gz',
+  'application/x-tar': 'tar',
+  'application/x-7z-compressed': '7z',
+  'application/x-rar-compressed': 'rar',
+  // 기타
+  'application/octet-stream': '*',
+};
+
+const ALLOWED_EXTENSIONS = [
+  // 이미지
+  'jpg', 'jpeg', 'png', 'gif', 'webp', 'svg', 'bmp', 'tiff', 'ico',
+  // 문서
+  'pdf', 'doc', 'docx', 'xls', 'xlsx', 'ppt', 'pptx', 'hwp', 'hwpx',
+  // 텍스트/코드
+  'txt', 'csv', 'html', 'css', 'js', 'ts', 'jsx', 'tsx', 'md',
+  'json', 'xml', 'yml', 'yaml', 'py', 'java', 'c', 'cpp', 'h',
+  'sql', 'sh', 'bat', 'log', 'ini', 'cfg', 'env',
+  // 압축
+  'zip', 'gz', 'tar', '7z', 'rar',
+];
+
+const MAX_FILE_SIZE_MB = 10;
 
 exports.handler = async (event) => {
   try {
-    // 프론트엔드에서 쿼리스트링으로 파일명과 타입(MIME)을 전달받음
     const { fileName, fileType } = event.queryStringParameters || {};
 
     if (!fileName || !fileType) {
@@ -18,26 +71,42 @@ exports.handler = async (event) => {
       };
     }
 
-    // 파일 이름 중복 방지를 위해 고유한 S3 객체 키(경로) 생성
-    // 예: uploads/123e4567-e89b-12d3.../my_photo.png
-    const fileExtension = fileName.split('.').pop();
+    // ── 파일 확장자 검증 ──────────────────────────────
+    const fileExtension = fileName.split('.').pop().toLowerCase();
+    if (!ALLOWED_EXTENSIONS.includes(fileExtension)) {
+      return {
+        statusCode: 400,
+        headers: { "Access-Control-Allow-Origin": "*" },
+        body: JSON.stringify({
+          message: `허용되지 않는 파일 확장자입니다: .${fileExtension}`,
+          allowedExtensions: ALLOWED_EXTENSIONS,
+        }),
+      };
+    }
+
+    // ── 파일 MIME 타입 검증 ──────────────────────────
+    if (!ALLOWED_TYPES[fileType]) {
+      return {
+        statusCode: 400,
+        headers: { "Access-Control-Allow-Origin": "*" },
+        body: JSON.stringify({
+          message: `허용되지 않는 파일 타입입니다: ${fileType}`,
+        }),
+      };
+    }
+
     const uniqueId = uuidv4();
     const s3ObjectKey = `uploads/${uniqueId}.${fileExtension}`;
+    const bucketName = process.env.RESOURCES_BUCKET;
 
-    // S3 버킷 이름 (환경 변수로 관리)
-    const bucketName = process.env.RESOURCES_BUCKET; 
-
-    // 업로드 커맨드 생성
     const command = new PutObjectCommand({
       Bucket: bucketName,
       Key: s3ObjectKey,
-      ContentType: fileType, // 프론트엔드에서 올리는 파일의 타입과 반드시 일치해야 함
+      ContentType: fileType,
+      ContentLength: MAX_FILE_SIZE_MB * 1024 * 1024,
     });
 
-    // 만료 시간이 5분(300초)인 임시 업로드 URL 생성
     const uploadUrl = await getSignedUrl(s3Client, command, { expiresIn: 300 });
-
-    // 프론트엔드에서 나중에 접근할 때 사용할 실제 파일의 퍼블릭 URL
     const fileUrl = `https://${bucketName}.s3.${process.env.AWS_REGION || "us-east-1"}.amazonaws.com/${s3ObjectKey}`;
 
     return {
@@ -48,15 +117,16 @@ exports.handler = async (event) => {
       },
       body: JSON.stringify({
         message: "업로드 URL 발급 성공",
-        uploadUrl: uploadUrl, // 프론트엔드가 파일 PUT 요청을 보낼 주소
-        fileUrl: fileUrl,     // DB에 저장하고 채팅창에 보여줄 파일 주소
-        s3ObjectKey: s3ObjectKey
+        uploadUrl,
+        fileUrl,
+        s3ObjectKey,
       }),
     };
   } catch (error) {
     console.error("S3 URL 발급 에러:", error);
     return {
       statusCode: 500,
+      headers: { "Access-Control-Allow-Origin": "*" },
       body: JSON.stringify({ message: "URL 발급 실패", error: error.message }),
     };
   }

--- a/backend/src/resources/saveLink.js
+++ b/backend/src/resources/saveLink.js
@@ -1,12 +1,14 @@
 const https = require("https");
 const http = require("http");
-// 🔥 GetCommand가 정상적으로 포함되었습니다
 const { UpdateCommand, GetCommand } = require("@aws-sdk/lib-dynamodb");
+const { S3Client, PutObjectCommand } = require("@aws-sdk/client-s3");
 const { v4: uuidv4 } = require("uuid");
 const dynamoDb = require("../dynamodbClient");
 const { verifyAccessToken } = require("../utils");
 
 const SERVERS_TABLE = process.env.SERVERS_TABLE;
+const RESOURCES_BUCKET = process.env.RESOURCES_BUCKET;
+const s3Client = new S3Client({ region: process.env.REGION || "us-east-1" });
 
 function fetchHtml(url, maxRedirects = 3) {
   return new Promise((resolve, reject) => {
@@ -44,6 +46,70 @@ function parseOgTags(html) {
   };
 }
 
+// OG 이미지를 S3에 캐싱
+function cacheOgImage(imageUrl) {
+  return new Promise((resolve, reject) => {
+    if (!imageUrl || !imageUrl.startsWith("http")) {
+      return resolve(null);
+    }
+
+    const client = imageUrl.startsWith("https") ? https : http;
+    client.get(imageUrl, { headers: { "User-Agent": "Mozilla/5.0" }, timeout: 8000 }, (res) => {
+      // 리다이렉트 처리
+      if ([301, 302, 303, 307].includes(res.statusCode) && res.headers.location) {
+        return resolve(cacheOgImage(res.headers.location));
+      }
+
+      if (res.statusCode !== 200) {
+        return resolve(null);
+      }
+
+      const contentType = res.headers["content-type"] || "image/jpeg";
+      // 이미지 타입이 아니면 스킵
+      if (!contentType.startsWith("image/")) {
+        return resolve(null);
+      }
+
+      const chunks = [];
+      let totalSize = 0;
+      const MAX_SIZE = 2 * 1024 * 1024; // 2MB 제한
+
+      res.on("data", (chunk) => {
+        totalSize += chunk.length;
+        if (totalSize > MAX_SIZE) {
+          res.destroy();
+          return resolve(null);
+        }
+        chunks.push(chunk);
+      });
+
+      res.on("end", async () => {
+        try {
+          const buffer = Buffer.concat(chunks);
+          const ext = contentType.split("/")[1]?.split(";")[0] || "jpg";
+          const s3Key = `og-cache/${uuidv4()}.${ext}`;
+
+          await s3Client.send(new PutObjectCommand({
+            Bucket: RESOURCES_BUCKET,
+            Key: s3Key,
+            Body: buffer,
+            ContentType: contentType,
+          }));
+
+          const cachedUrl = `https://${RESOURCES_BUCKET}.s3.${process.env.REGION || "us-east-1"}.amazonaws.com/${s3Key}`;
+          resolve(cachedUrl);
+        } catch (err) {
+          console.warn("OG 이미지 S3 캐싱 실패:", err.message);
+          resolve(null);
+        }
+      });
+
+      res.on("error", () => resolve(null));
+    }).on("error", () => resolve(null))
+      .on("timeout", () => resolve(null));
+  });
+}
+
 exports.handler = async (event) => {
   try {
     const auth = verifyAccessToken(event.headers?.Authorization || event.headers?.authorization);
@@ -59,7 +125,7 @@ exports.handler = async (event) => {
     const body = JSON.parse(event.body || "{}");
 
     // ──────────────────────────────────────────
-    // 🚧 삭제 요청 최우선 처리 (URL 검사 전에 실행)
+    // 삭제 요청 처리
     // ──────────────────────────────────────────
     if (body.action === "delete") {
       const { linkId } = body;
@@ -86,7 +152,7 @@ exports.handler = async (event) => {
     }
 
     // ──────────────────────────────────────────
-    // 💾 링크 저장 로직
+    // 링크 저장 로직
     // ──────────────────────────────────────────
     const { url } = body;
 
@@ -114,12 +180,22 @@ exports.handler = async (event) => {
       console.warn("OG 파싱 실패:", err.message);
     }
 
+    // OG 이미지가 있으면 S3에 캐싱
+    let cachedImageUrl = ogData.image;
+    if (ogData.image) {
+      const cached = await cacheOgImage(ogData.image);
+      if (cached) {
+        cachedImageUrl = cached;
+      }
+    }
+
     const linkItem = {
       linkId: uuidv4(),
       url,
       title: ogData.title,
       description: ogData.description,
-      image: ogData.image,
+      image: cachedImageUrl,
+      originalImage: ogData.image,
       siteName: ogData.siteName,
       sharedBy: auth.userId,
       sharedAt: new Date().toISOString(),


### PR DESCRIPTION
## 📌 관련 이슈
#(이슈 번호)

## 🏷️ 작업 유형 (Type of Change)
- [x] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Fix)
- [ ] 🎨 UI/UX 및 디자인 변경 (Design)
- [ ] ♻️ 리팩토링 (Refactor)
- [ ] 📝 문서 작업 (Docs)

## 🚀 작업 내용

### 파일 업로드 검증 강화 (`getUploadUrl.js`)
- 허용 파일 확장자 화이트리스트 추가 (이미지, 문서, 텍스트/코드, 압축 등 40종+)
- 허용 MIME 타입 화이트리스트 추가 (image/*, application/pdf, text/* 등 30종+)
- 허용되지 않는 파일 업로드 시도 시 400 에러 + 허용 확장자 목록 반환
- AI 분석(Textract, Rekognition) 대상 파일 타입을 고려한 현실적 제한

### OG 이미지 S3 캐싱 (`saveLink.js`)
- 링크 공유 시 OpenGraph 이미지를 S3 `og-cache/` 폴더에 자동 다운로드 저장
- 외부 서버 이미지 삭제/만료 시에도 캐시된 이미지로 안정적 표시
- 2MB 초과 이미지는 캐싱 스킵 (원본 URL 유지)
- 캐싱 실패 시 에러 없이 원본 URL fallback
- `image`: 캐싱된 S3 URL, `originalImage`: 원본 URL 둘 다 저장

## ✅ 체크리스트
- [x] `README.md`에 명시된 코딩 컨벤션 및 커밋 메시지 규칙을 준수했습니다.
- [x] 관련 없는 코드나 불필요한 주석을 포함하지 않았습니다.
- [x] 작업할 브랜치(예: `dev`)의 최신 상태를 pull 받아 충돌이 없는 것을 확인했습니다.
- [x] (Backend) 람다 함수나 DB 스키마 변경 시 로컬/테스트 환경에서 검증을 완료했습니다.

## 💬 리뷰어에게
- `getUploadUrl`의 파일 타입 제한은 프론트에서도 동일하게 안내해주면 좋습니다 (허용되지 않는 확장자 업로드 시 사용자 피드백).
- OG 이미지 캐싱은 S3 `og-cache/` 폴더에 저장됩니다. 퍼블릭 읽기 정책이 `uploads/*`만 적용되어 있으므로, `og-cache/*`에 대한 퍼블릭 읽기 정책 추가가 필요합니다. -> 해결 완료