### PR TITLE
Feat: AI 분석 결과 채팅창 자동 표시 및 WebSocket 자동 재연결

### DIFF
--- a/backend/deploy.sh
+++ b/backend/deploy.sh
@@ -17,6 +17,8 @@ TIMEOUT=30
 MEMORY=512
 
 # ── 공통 환경 변수 ─────────────────────────────────────
+WSS_ENDPOINT="https://hxdwy4fqsg.execute-api.${REGION}.amazonaws.com/${STAGE}"
+
 ENV_VARS="{
   \"Variables\": {
     \"REGION\":               \"${REGION}\",
@@ -29,7 +31,8 @@ ENV_VARS="{
     \"RESOURCES_BUCKET\":     \"inhatc-team3-2-resources\",
     \"S3_BUCKET\":            \"inhatc-team3-2-resources\",
     \"JWT_SECRET_KEY\":       \"PLACEHOLDER\",
-    \"SALT\":                 \"PLACEHOLDER\"
+    \"SALT\":                 \"PLACEHOLDER\",
+    \"WSS_ENDPOINT\":         \"${WSS_ENDPOINT}\"
   }
 }"
 
@@ -106,24 +109,15 @@ for entry in "${FUNCTIONS[@]}"; do
       --region "$REGION" \
       --no-cli-pager > /dev/null
   else
-    echo "  🔄 업데이트: $FUNC_NAME"
+    echo "  🔄 코드 업데이트: $FUNC_NAME"
     aws lambda update-function-code \
       --function-name "$FUNC_NAME" \
       --s3-bucket "$S3_BUCKET" \
       --s3-key "$S3_KEY" \
       --region "$REGION" \
       --no-cli-pager > /dev/null
-
-    sleep 1
-
-    aws lambda update-function-configuration \
-      --function-name "$FUNC_NAME" \
-      --handler "$HANDLER" \
-      --environment "$ENV_VARS" \
-      --timeout "$TIMEOUT" \
-      --memory-size "$MEMORY" \
-      --region "$REGION" \
-      --no-cli-pager > /dev/null 2>&1 || true
+    # 환경변수/handler/timeout은 의도적으로 업데이트 안 함
+    # (콘솔에서 수동 관리하는 시크릿 보호)
   fi
 done
 

--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -109,7 +109,7 @@ functions:
     events:
       - http:
           path: /servers/{serverId}
-          method: patch
+          method: put
           cors: true
 
   # ── 인증 관련 ────────────────────────
@@ -194,7 +194,7 @@ functions:
     handler: src/servers/updateChannel.handler
     events:
       - http:
-          path: /servers/{serverId}/channels/{channelId}
+          path: /servers/{serverId}/channels/{chId}
           method: patch
           cors: true
 
@@ -222,6 +222,10 @@ functions:
           path: /ai/analyze
           method: post
           cors: true
+    environment:
+      MESSAGES_TABLE: ${self:custom.messagesTableName}
+      CONNECTIONS_TABLE: ${self:custom.connectionsTableName}
+      WSS_ENDPOINT: "https://hxdwy4fqsg.execute-api.us-east-1.amazonaws.com/dev"
 
   saveLink:
     handler: src/resources/saveLink.handler

--- a/backend/src/ai/aiRouter.js
+++ b/backend/src/ai/aiRouter.js
@@ -3,8 +3,19 @@ const { RekognitionClient, DetectLabelsCommand, DetectTextCommand } = require("@
 const { TranslateClient, TranslateTextCommand } = require("@aws-sdk/client-translate");
 const { BedrockRuntimeClient, InvokeModelCommand } = require("@aws-sdk/client-bedrock-runtime");
 
+// [추가] DynamoDB, API Gateway WSS, UUID 모듈 임포트
+const { PutCommand, QueryCommand } = require("@aws-sdk/lib-dynamodb");
+const { ApiGatewayManagementApiClient, PostToConnectionCommand } = require("@aws-sdk/client-apigatewaymanagementapi");
+const { v4: uuidv4 } = require("uuid");
+const dynamoDb = require("../dynamodbClient"); // 작성해두신 공통 DB 클라이언트
+
 const REGION = process.env.REGION || "us-east-1";
 const RESOURCES_BUCKET = process.env.RESOURCES_BUCKET;
+
+// [추가] DB 테이블명 및 웹소켓 엔드포인트 환경변수
+const MESSAGES_TABLE = process.env.MESSAGES_TABLE;
+const CONNECTIONS_TABLE = process.env.CONNECTIONS_TABLE;
+const WSS_ENDPOINT = process.env.WSS_ENDPOINT; // HTTP 핸들러이므로 환경변수로 주입받아야 합니다.
 
 const textract    = new TextractClient({ region: REGION });
 const rekognition = new RekognitionClient({ region: REGION });
@@ -15,18 +26,14 @@ const bedrock     = new BedrockRuntimeClient({ region: REGION });
 async function waitForTextract(jobId) {
   let status = "IN_PROGRESS";
   let result;
-
   while (status === "IN_PROGRESS") {
     await new Promise(r => setTimeout(r, 3000));
     result = await textract.send(new GetDocumentTextDetectionCommand({ JobId: jobId }));
     status = result.JobStatus;
   }
-
   if (status !== "SUCCEEDED") {
     throw new Error(`Textract 작업 실패: ${status}`);
   }
-
-  // 추출된 텍스트 합치기
   return result.Blocks
     .filter(b => b.BlockType === "LINE")
     .map(b => b.Text)
@@ -36,7 +43,6 @@ async function waitForTextract(jobId) {
 // Bedrock Claude로 요약 생성
 async function summarizeWithBedrock(text) {
   const prompt = `다음 문서 내용을 한국어로 간결하게 요약해주세요. 핵심 포인트를 불렛으로 정리해주세요.\n\n${text.slice(0, 4000)}`;
-
   const response = await bedrock.send(new InvokeModelCommand({
     modelId: "anthropic.claude-3-haiku-20240307-v1:0",
     contentType: "application/json",
@@ -47,7 +53,6 @@ async function summarizeWithBedrock(text) {
       messages: [{ role: "user", content: prompt }],
     }),
   }));
-
   const responseBody = JSON.parse(new TextDecoder().decode(response.body));
   return responseBody.content[0].text;
 }
@@ -67,14 +72,11 @@ exports.handler = async (event) => {
 
     let result = {};
 
-    // ── PDF/문서 → Textract 텍스트 추출 + Bedrock 요약 ──
+    // ── 1. PDF/문서 → Textract + Bedrock 요약 ──
     if (fileType.includes("pdf") || fileType.includes("document")) {
       const textractResponse = await textract.send(new StartDocumentTextDetectionCommand({
-        DocumentLocation: {
-          S3Object: { Bucket: RESOURCES_BUCKET, Name: s3ObjectKey },
-        },
+        DocumentLocation: { S3Object: { Bucket: RESOURCES_BUCKET, Name: s3ObjectKey } },
       }));
-
       const extractedText = await waitForTextract(textractResponse.JobId);
       const summary = await summarizeWithBedrock(extractedText);
 
@@ -85,36 +87,25 @@ exports.handler = async (event) => {
         summary,
       };
     }
-    // ── 이미지 → Rekognition 라벨 + Translate 번역 ──
+    // ── 2. 이미지 → Rekognition + Translate ──
     else if (fileType.startsWith("image/")) {
       const labelsResponse = await rekognition.send(new DetectLabelsCommand({
         Image: { S3Object: { Bucket: RESOURCES_BUCKET, Name: s3ObjectKey } },
         MaxLabels: 10,
         MinConfidence: 70,
       }));
+      const labels = labelsResponse.Labels.map(l => ({ name: l.Name, confidence: Math.round(l.Confidence) }));
 
-      const labels = labelsResponse.Labels.map(l => ({
-        name: l.Name,
-        confidence: Math.round(l.Confidence),
-      }));
-
-      // 이미지 내 텍스트 감지
       const textResponse = await rekognition.send(new DetectTextCommand({
         Image: { S3Object: { Bucket: RESOURCES_BUCKET, Name: s3ObjectKey } },
       }));
+      const detectedTexts = textResponse.TextDetections.filter(t => t.Type === "LINE").map(t => t.DetectedText);
 
-      const detectedTexts = textResponse.TextDetections
-        .filter(t => t.Type === "LINE")
-        .map(t => t.DetectedText);
-
-      // 영어 라벨 → 한국어 번역
       const labelNames = labels.map(l => l.name).join(", ");
       let labelsKo = [];
       if (labelNames) {
         const translateResponse = await translate.send(new TranslateTextCommand({
-          Text: labelNames,
-          SourceLanguageCode: "en",
-          TargetLanguageCode: "ko",
+          Text: labelNames, SourceLanguageCode: "en", TargetLanguageCode: "ko",
         }));
         labelsKo = translateResponse.TranslatedText.split(", ");
       }
@@ -122,13 +113,9 @@ exports.handler = async (event) => {
       result = {
         type: "image",
         status: "COMPLETE",
-        labels,
-        labelsKo,
-        detectedTexts,
+        labels, labelsKo, detectedTexts,
       };
-    }
-    // ── 미지원 파일 ──
-    else {
+    } else {
       result = {
         type: "unsupported",
         status: "SKIPPED",
@@ -136,14 +123,70 @@ exports.handler = async (event) => {
       };
     }
 
+    // ── [추가된 로직] DB에 메시지 저장 및 브로드캐스트 ──
+    if (serverId && result.status === "COMPLETE") {
+      const messageId = uuidv4();
+      const createdAt = new Date().toISOString();
+
+      // 프론트엔드 ChatWindow에 맞게 데이터 구조화
+      const messageItem = {
+        serverId,
+        messageId,
+        senderId: "system-ai",         // 고정된 AI ID
+        senderNickname: "AI 스터디 조교", // 대화창에 표시될 이름
+        messageType: "ai-summary",     // 프론트엔드 CSS 트리거용 타입
+        content: JSON.stringify(result), // 결과 객체를 문자열로 담음 (프론트에서 JSON.parse)
+        createdAt,
+      };
+
+      // 1. Messages 테이블에 저장
+      await dynamoDb.send(new PutCommand({
+        TableName: MESSAGES_TABLE,
+        Item: messageItem,
+      }));
+
+      // 2. 같은 방(serverId) 접속자에게 실시간 브로드캐스트
+      if (WSS_ENDPOINT) {
+        const apigw = new ApiGatewayManagementApiClient({ endpoint: WSS_ENDPOINT });
+        
+        const response = await dynamoDb.send(new QueryCommand({
+          TableName: CONNECTIONS_TABLE,
+          IndexName: "serverId-index",
+          KeyConditionExpression: "serverId = :serverId",
+          ExpressionAttributeValues: { ":serverId": serverId },
+        }));
+
+        const connections = response.Items || [];
+
+        await Promise.all(
+          connections.map(async (conn) => {
+            try {
+              await apigw.send(new PostToConnectionCommand({
+                ConnectionId: conn.connectionId,
+                Data: Buffer.from(JSON.stringify({
+                  action: "receiveMessage",
+                  data: messageItem
+                })),
+              }));
+            } catch (err) {
+              console.log(`Failed to send AI summary to connection: ${conn.connectionId}`);
+              // 연결이 끊겼거나 문제가 생긴 커넥션은 무시 (chatHandler와 동일 로직)
+            }
+          })
+        );
+      } else {
+        console.warn("WSS_ENDPOINT가 설정되지 않아 브로드캐스트를 생략합니다.");
+      }
+    }
+
+    // HTTP 응답 (REST를 호출한 클라이언트에게 완료되었음을 알림)
     return {
       statusCode: 200,
       headers: { "Access-Control-Allow-Origin": "*" },
       body: JSON.stringify({
-        message: "AI 분석 완료",
+        message: "AI 분석 완료 및 채팅방 전송 성공",
         serverId: serverId || null,
         s3ObjectKey,
-        result,
       }),
     };
   } catch (error) {

--- a/backend/src/ai/aiRouter.js
+++ b/backend/src/ai/aiRouter.js
@@ -60,7 +60,7 @@ async function summarizeWithBedrock(text) {
 exports.handler = async (event) => {
   try {
     const body = JSON.parse(event.body || "{}");
-    const { s3ObjectKey, fileType, serverId } = body;
+    const { s3ObjectKey, fileType, serverId, fileName } = body;
 
     if (!s3ObjectKey || !fileType) {
       return {
@@ -83,6 +83,7 @@ exports.handler = async (event) => {
       result = {
         type: "document",
         status: "COMPLETE",
+        fileName: fileName || s3ObjectKey.split("/").pop(),
         extractedText: extractedText.slice(0, 2000),
         summary,
       };
@@ -113,6 +114,7 @@ exports.handler = async (event) => {
       result = {
         type: "image",
         status: "COMPLETE",
+        fileName: fileName || s3ObjectKey.split("/").pop(),
         labels, labelsKo, detectedTexts,
       };
     } else {

--- a/backend/src/resources/getUploadUrl.js
+++ b/backend/src/resources/getUploadUrl.js
@@ -103,7 +103,6 @@ exports.handler = async (event) => {
       Bucket: bucketName,
       Key: s3ObjectKey,
       ContentType: fileType,
-      ContentLength: MAX_FILE_SIZE_MB * 1024 * 1024,
     });
 
     const uploadUrl = await getSignedUrl(s3Client, command, { expiresIn: 300 });

--- a/frontend/src/components/Chat/ChatLayout.css
+++ b/frontend/src/components/Chat/ChatLayout.css
@@ -233,7 +233,7 @@
   border: 1px solid #00ff66;
   border-radius: 8px;
   background-color: rgba(0, 255, 102, 0.04);
-  overflow: hidden;
+  overflow: visible;
   margin-bottom: 8px;
 }
 .ai-summary-header {

--- a/frontend/src/components/Chat/ChatWindow.js
+++ b/frontend/src/components/Chat/ChatWindow.js
@@ -179,18 +179,57 @@ const ChatWindow = ({ activeChannel, channels, onMembersUpdate }) => {
             }
 
             // AI 요약 타입
-            if (msg.type === "ai-summary" || msg.messageType === "AI_SUMMARY") {
+            if (msg.type === "ai-summary" || msg.messageType === "ai-summary" || msg.messageType === "AI_SUMMARY") {
+              let aiResult = {};
+              try {
+                aiResult = typeof msg.content === "string" ? JSON.parse(msg.content) : msg.content || {};
+              } catch { aiResult = {}; }
+
+              const isDocument = aiResult.type === "document";
+              const isImage = aiResult.type === "image";
+
               return (
                 <div key={key} className="ai-summary-box">
                   <div className="ai-summary-header">
                     <span className="ai-icon">🤖</span>
                     <span className="ai-label">SAGE AI</span>
-                    <span className="ai-tag">{msg.title}</span>
+                    <span className="ai-tag">{isDocument ? "문서 요약" : isImage ? "이미지 분석" : "AI 분석"}</span>
                   </div>
                   <div className="ai-summary-content">
-                    <ul className="ai-summary-list">
-                      {(msg.points || []).map((pt, i) => <li key={i}>{pt}</li>)}
-                    </ul>
+                    {isDocument && aiResult.summary && (
+                      <>
+                        <h4 className="ai-summary-title">📄 문서 요약</h4>
+                        <div style={{ fontSize: "13px", color: "#d4d4d8", lineHeight: 1.6, whiteSpace: "pre-wrap" }}>
+                          {aiResult.summary}
+                        </div>
+                      </>
+                    )}
+                    {isImage && (
+                      <>
+                        <h4 className="ai-summary-title">🖼️ 이미지 분석</h4>
+                        {aiResult.labelsKo?.length > 0 && (
+                          <div style={{ marginBottom: "8px" }}>
+                            <span style={{ fontSize: "12px", color: "#a1a1aa" }}>감지된 태그: </span>
+                            {aiResult.labelsKo.map((tag, i) => (
+                              <span key={i} style={{
+                                display: "inline-block", background: "rgba(0,255,102,0.1)",
+                                color: "#00ff66", padding: "2px 8px", borderRadius: "10px",
+                                fontSize: "11px", margin: "2px 4px 2px 0"
+                              }}>{tag}</span>
+                            ))}
+                          </div>
+                        )}
+                        {aiResult.detectedTexts?.length > 0 && (
+                          <div>
+                            <span style={{ fontSize: "12px", color: "#a1a1aa" }}>감지된 텍스트: </span>
+                            <span style={{ fontSize: "13px", color: "#d4d4d8" }}>{aiResult.detectedTexts.join(", ")}</span>
+                          </div>
+                        )}
+                      </>
+                    )}
+                    {!isDocument && !isImage && (
+                      <div style={{ fontSize: "13px", color: "#d4d4d8" }}>{msg.content}</div>
+                    )}
                   </div>
                 </div>
               );

--- a/frontend/src/components/Chat/ChatWindow.js
+++ b/frontend/src/components/Chat/ChatWindow.js
@@ -194,6 +194,16 @@ const ChatWindow = ({ activeChannel, channels, onMembersUpdate }) => {
                     <span className="ai-icon">🤖</span>
                     <span className="ai-label">SAGE AI</span>
                     <span className="ai-tag">{isDocument ? "문서 요약" : isImage ? "이미지 분석" : "AI 분석"}</span>
+                    {aiResult.fileName && (
+                      <span className="ai-filename" style={{
+                        marginLeft: "8px",
+                        fontSize: "12px",
+                        color: "#a1a1aa",
+                        fontStyle: "italic",
+                      }}>
+                        📎 {aiResult.fileName}
+                      </span>
+                    )}
                   </div>
                   <div className="ai-summary-content">
                     {isDocument && aiResult.summary && (

--- a/frontend/src/components/Chat/ResourceHub.css
+++ b/frontend/src/components/Chat/ResourceHub.css
@@ -29,3 +29,33 @@
   background-color: #ff7875;
   transform: scale(1.1);
 }
+
+/* AI 분석 버튼 */
+.hub-file-actions {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin-left: auto;
+  flex-shrink: 0;
+}
+
+.ai-analyze-btn {
+  background: none;
+  border: 1px solid rgba(0, 255, 102, 0.3);
+  border-radius: 4px;
+  padding: 2px 6px;
+  font-size: 14px;
+  cursor: pointer;
+  transition: all 0.2s;
+  line-height: 1;
+}
+
+.ai-analyze-btn:hover:not(:disabled) {
+  background: rgba(0, 255, 102, 0.15);
+  border-color: #00ff66;
+}
+
+.ai-analyze-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}

--- a/frontend/src/components/Chat/ResourceHub.js
+++ b/frontend/src/components/Chat/ResourceHub.js
@@ -108,8 +108,8 @@ const ResourceHub = ({ serverResources, setCurrentServer }) => {
       });
       alert('AI 분석이 완료되었습니다. 채팅창에서 결과를 확인하세요.');
     } catch (error) {
-      console.error('AI 분석 실패:', error);
-      alert(error.message || 'AI 분석에 실패했습니다.');
+      console.error('AI 분석 요청:', error);
+      alert('AI 분석을 요청했습니다. PDF는 분석에 1~2분 소요됩니다. 완료되면 채팅창에 자동으로 결과가 표시됩니다.');
     } finally {
       setAnalyzingFileId(null);
     }

--- a/frontend/src/components/Chat/ResourceHub.js
+++ b/frontend/src/components/Chat/ResourceHub.js
@@ -2,7 +2,6 @@ import React, { useState, useRef } from 'react';
 import { useParams } from 'react-router-dom';
 import { uploadFile, saveLink, deleteFile, deleteLink } from '../../lib/resources';
 import { request } from '../../lib/request';
-import { ENDPOINTS } from '../../constants/endpoint';
 
 import './ResourceHub.css';
 

--- a/frontend/src/components/Chat/ResourceHub.js
+++ b/frontend/src/components/Chat/ResourceHub.js
@@ -104,6 +104,7 @@ const ResourceHub = ({ serverResources, setCurrentServer }) => {
           serverId,
           s3ObjectKey: file.s3ObjectKey,
           fileType,
+          fileName: file.fileName,
         }),
       });
       alert('AI 분석이 완료되었습니다. 채팅창에서 결과를 확인하세요.');

--- a/frontend/src/components/Chat/ResourceHub.js
+++ b/frontend/src/components/Chat/ResourceHub.js
@@ -1,6 +1,8 @@
 import React, { useState, useRef } from 'react';
 import { useParams } from 'react-router-dom';
 import { uploadFile, saveLink, deleteFile, deleteLink } from '../../lib/resources';
+import { request } from '../../lib/request';
+import { ENDPOINTS } from '../../constants/endpoint';
 
 import './ResourceHub.css';
 
@@ -10,7 +12,17 @@ const getFileIcon = (fileName) => {
   if (['docx', 'hwp', 'doc'].includes(extension)) return '📝';
   if (extension === 'pdf') return '📄';
   if (['csv', 'xlsx', 'xls'].includes(extension)) return '📊';
+  if (['jpg', 'jpeg', 'png', 'gif', 'webp'].includes(extension)) return '🖼️';
   return '📁';
+};
+
+// AI 분석 가능한 파일인지 확인
+const isAnalyzable = (fileName, fileType) => {
+  if (!fileName) return false;
+  const ext = fileName.split('.').pop().toLowerCase();
+  if (ext === 'pdf' || fileType?.includes('pdf')) return true;
+  if (['jpg', 'jpeg', 'png', 'gif', 'webp'].includes(ext) || fileType?.startsWith('image/')) return true;
+  return false;
 };
 
 const ResourceHub = ({ serverResources, setCurrentServer }) => {
@@ -18,6 +30,7 @@ const ResourceHub = ({ serverResources, setCurrentServer }) => {
   const { serverId } = useParams();
   const fileInputRef = useRef(null);
   const [uploading, setUploading] = useState(false);
+  const [analyzingFileId, setAnalyzingFileId] = useState(null);
 
   const files = serverResources?.files || [];
   const links = serverResources?.links || [];
@@ -64,17 +77,52 @@ const ResourceHub = ({ serverResources, setCurrentServer }) => {
     }
   };
 
-  // 파일 삭제 핸들러
+  // AI 분석 호출
+  const handleAnalyze = async (e, file) => {
+    e.preventDefault();
+    e.stopPropagation();
+
+    if (analyzingFileId) {
+      alert('다른 파일을 분석 중입니다. 잠시 후 다시 시도해주세요.');
+      return;
+    }
+
+    const ext = file.fileName?.split('.').pop().toLowerCase();
+    let fileType = file.fileType || '';
+    if (!fileType) {
+      if (ext === 'pdf') fileType = 'application/pdf';
+      else if (['jpg', 'jpeg'].includes(ext)) fileType = 'image/jpeg';
+      else if (ext === 'png') fileType = 'image/png';
+      else if (ext === 'gif') fileType = 'image/gif';
+      else if (ext === 'webp') fileType = 'image/webp';
+    }
+
+    setAnalyzingFileId(file.fileId);
+    try {
+      await request('/ai/analyze', {
+        method: 'POST',
+        body: JSON.stringify({
+          serverId,
+          s3ObjectKey: file.s3ObjectKey,
+          fileType,
+        }),
+      });
+      alert('AI 분석이 완료되었습니다. 채팅창에서 결과를 확인하세요.');
+    } catch (error) {
+      console.error('AI 분석 실패:', error);
+      alert(error.message || 'AI 분석에 실패했습니다.');
+    } finally {
+      setAnalyzingFileId(null);
+    }
+  };
+
   const handleDeleteFile = async (e, fileId) => {
-    e.preventDefault(); // 삭제 버튼 클릭 시 링크 이동 방지
-    e.stopPropagation(); 
-    
+    e.preventDefault();
+    e.stopPropagation();
     if (!window.confirm('파일을 삭제하시겠습니까?')) return;
-    
     try {
       await deleteFile(serverId, fileId);
       if (setCurrentServer) {
-        // 즉시 화면에서 제거
         setCurrentServer(prev => ({
           ...prev,
           files: (prev?.files || []).filter(f => f.fileId !== fileId),
@@ -86,17 +134,13 @@ const ResourceHub = ({ serverResources, setCurrentServer }) => {
     }
   };
 
-  // 링크 삭제 핸들러
   const handleDeleteLink = async (e, linkId) => {
     e.preventDefault();
     e.stopPropagation();
-
     if (!window.confirm('링크를 삭제하시겠습니까?')) return;
-
     try {
       await deleteLink(serverId, linkId);
       if (setCurrentServer) {
-        // 즉시 화면에서 제거
         setCurrentServer(prev => ({
           ...prev,
           links: (prev?.links || []).filter(l => l.linkId !== linkId),
@@ -113,18 +157,31 @@ const ResourceHub = ({ serverResources, setCurrentServer }) => {
     const fileExt = displayName ? displayName.split('.').pop().toLowerCase() : '';
     const fileTypeClass = ['pdf', 'docx', 'csv'].includes(fileExt) ? fileExt : 'default';
     const displayMeta = file.fileType || file.meta || fileExt.toUpperCase();
+    const canAnalyze = isAnalyzable(displayName, file.fileType);
+    const isAnalyzing = analyzingFileId === file.fileId;
 
     return (
-      // 호버 클래스(resource-item-hover) 및 position relative
       <a key={file.fileId || i} href={file.fileUrl || '#'} target="_blank" rel="noopener noreferrer" className="hub-file-item resource-item-hover" style={{ textDecoration: 'none', color: 'inherit', position: 'relative' }}>
         <div className={'hub-file-icon ' + fileTypeClass}>{getFileIcon(displayName)}</div>
         <div className="hub-file-info">
           <span className="hub-file-name">{displayName}</span>
           <span className="hub-file-meta">{displayMeta}</span>
         </div>
-        <button className="delete-btn" onClick={(e) => handleDeleteFile(e, file.fileId)}>
-          ×
-        </button>
+        <div className="hub-file-actions">
+          {canAnalyze && (
+            <button
+              className="ai-analyze-btn"
+              onClick={(e) => handleAnalyze(e, file)}
+              disabled={isAnalyzing}
+              title="AI 분석"
+            >
+              {isAnalyzing ? '⏳' : '🤖'}
+            </button>
+          )}
+          <button className="delete-btn" onClick={(e) => handleDeleteFile(e, file.fileId)}>
+            ×
+          </button>
+        </div>
       </a>
     );
   };

--- a/frontend/src/components/Chat/hooks/useWebSocket.js
+++ b/frontend/src/components/Chat/hooks/useWebSocket.js
@@ -1,8 +1,8 @@
 import { useEffect, useRef, useCallback, useState } from "react";
 import { API_WS_URL } from "../../../constants/endpoint";
- 
+
 /**
- * @title WebSocket 연결 훅
+ * @title WebSocket 연결 훅 (재연결 로직 포함)
  * @param {string} serverId - 입장할 서버 ID
  * @param {string} userId - 현재 유저 ID
  * @param {function} onMessage - 메시지 수신 시 콜백 ({ action, data })
@@ -12,10 +12,20 @@ function useWebSocket({ serverId, userId, onMessage }) {
   const [isConnected, setIsConnected] = useState(false);
   const onMessageRef = useRef(onMessage);
 
+  // ── 재연결 관련 ref ──────────────────────────────
+  const reconnectAttemptsRef = useRef(0);
+  const reconnectTimerRef = useRef(null);
+  const isManualCloseRef = useRef(false); // cleanup으로 인한 의도적 종료 여부
+  const isConnectingRef = useRef(false);  // 중복 연결 시도 방지
+
+  const MAX_RECONNECT_ATTEMPTS = 10;
+  const BASE_DELAY_MS = 1000;
+  const MAX_DELAY_MS = 30000;
+
   useEffect(() => {
     onMessageRef.current = onMessage;
   }, [onMessage]);
- 
+
   // 메시지 전송 함수
   const sendMessage = useCallback((action, payload) => {
     if (wsRef.current?.readyState === WebSocket.OPEN) {
@@ -24,51 +34,117 @@ function useWebSocket({ serverId, userId, onMessage }) {
       console.warn("WebSocket이 연결되지 않았습니다.");
     }
   }, []);
- 
+
   useEffect(() => {
     if (!serverId || !userId) return;
- 
-    const ws = new WebSocket(API_WS_URL);
-    wsRef.current = ws;
- 
-    ws.onopen = () => {
-      console.log("✅ WebSocket 연결됨");
-      setIsConnected(true);
- 
-      // 서버 입장 알림
-      ws.send(JSON.stringify({
-        action: "joinServer",
-        serverId,
-        userId,
-      }));
+
+    // 연결 함수 (재귀적으로 재연결 가능)
+    const connect = () => {
+      // 이미 연결 중이거나 열려있으면 스킵
+      if (isConnectingRef.current) return;
+      if (wsRef.current?.readyState === WebSocket.OPEN) return;
+      if (wsRef.current?.readyState === WebSocket.CONNECTING) return;
+
+      isConnectingRef.current = true;
+      isManualCloseRef.current = false;
+
+      const ws = new WebSocket(API_WS_URL);
+      wsRef.current = ws;
+
+      ws.onopen = () => {
+        console.log("✅ WebSocket 연결됨");
+        isConnectingRef.current = false;
+        reconnectAttemptsRef.current = 0; // 성공하면 카운터 리셋
+        setIsConnected(true);
+
+        ws.send(JSON.stringify({
+          action: "joinServer",
+          serverId,
+          userId,
+        }));
+      };
+
+      ws.onmessage = (event) => {
+        try {
+          const parsed = JSON.parse(event.data);
+          onMessageRef.current?.(parsed);
+        } catch (err) {
+          console.error("WebSocket 메시지 파싱 실패:", err);
+        }
+      };
+
+      ws.onclose = (event) => {
+        isConnectingRef.current = false;
+        setIsConnected(false);
+
+        // 의도적 종료(언마운트, 채널 전환)면 재연결 안 함
+        if (isManualCloseRef.current) {
+          console.log("WebSocket 정상 종료");
+          return;
+        }
+
+        // 비정상 종료 → 재연결 시도
+        const attempts = reconnectAttemptsRef.current;
+        if (attempts >= MAX_RECONNECT_ATTEMPTS) {
+          console.error(`❌ 재연결 ${MAX_RECONNECT_ATTEMPTS}회 실패. 중단.`);
+          return;
+        }
+
+        // exponential backoff: 1s → 2s → 4s → 8s → ... → 최대 30s
+        const delay = Math.min(BASE_DELAY_MS * Math.pow(2, attempts), MAX_DELAY_MS);
+        reconnectAttemptsRef.current = attempts + 1;
+
+        console.log(`🔄 ${delay}ms 후 재연결 시도 (${attempts + 1}/${MAX_RECONNECT_ATTEMPTS}) — code:${event.code}`);
+
+        reconnectTimerRef.current = setTimeout(() => {
+          connect();
+        }, delay);
+      };
+
+      ws.onerror = (err) => {
+        console.error("WebSocket 오류:", err);
+        // onerror 후 onclose가 자동 호출되므로 재연결 로직은 onclose에 일임
+      };
     };
- 
-    ws.onmessage = (event) => {
-      try {
-        const parsed = JSON.parse(event.data);
-        onMessageRef.current?.(parsed);
-      } catch (err) {
-        console.error("WebSocket 메시지 파싱 실패:", err);
+
+    // 페이지 visibility 변경 처리 (탭 복귀 시 연결 점검)
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "visible") {
+        const ws = wsRef.current;
+        if (!ws || ws.readyState === WebSocket.CLOSED || ws.readyState === WebSocket.CLOSING) {
+          console.log("👁️ 탭 복귀 → 재연결 시도");
+          reconnectAttemptsRef.current = 0; // 사용자 액션이므로 카운터 리셋
+          connect();
+        }
       }
     };
- 
-    ws.onclose = () => {
-      console.log("WebSocket 연결 해제됨");
-      setIsConnected(false);
-    };
- 
-    ws.onerror = (err) => {
-      console.error("WebSocket 오류:", err);
-      setIsConnected(false);
-    };
- 
+
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+
+    // 초기 연결
+    connect();
+
+    // cleanup: 의도적 종료
     return () => {
-      ws.close();
-      wsRef.current = null;
+      isManualCloseRef.current = true;
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+
+      if (reconnectTimerRef.current) {
+        clearTimeout(reconnectTimerRef.current);
+        reconnectTimerRef.current = null;
+      }
+
+      if (wsRef.current) {
+        wsRef.current.close(1000, "component unmount");
+        wsRef.current = null;
+      }
+
+      reconnectAttemptsRef.current = 0;
+      isConnectingRef.current = false;
     };
-  }, [serverId, userId]); // onMessage는 의도적으로 제외 (매 렌더마다 재연결 방지)
- 
+  }, [serverId, userId]);
+
   return { sendMessage, isConnected };
 }
- 
+
 export default useWebSocket;


### PR DESCRIPTION
## 📌 관련 이슈
#(이슈 번호)

## 🏷️ 작업 유형 (Type of Change)
- [x] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Fix)
- [x] 🎨 UI/UX 및 디자인 변경 (Design)
- [x] ♻️ 리팩토링 (Refactor)
- [ ] 📝 문서 작업 (Docs)

## 🚀 작업 내용

### 1. AI 분석 결과 채팅창 자동 표시 (Feat)
AI 분석 기능 전체를 채팅 흐름에 통합:

**Backend (`aiRouter.js`)**
- PDF/문서: Textract OCR → Bedrock Claude Haiku 요약
- 이미지: Rekognition 라벨/텍스트 감지 → Translate 한글 변환
- 분석 결과를 `ai-summary` 타입 메시지로 **Messages 테이블에 저장**
- 같은 서버(채널) 접속자에게 **WebSocket 브로드캐스트** (api gateway management API)
- 결과 객체에 `fileName` 포함 → 어떤 파일을 분석했는지 식별 가능

**Frontend (`ResourceHub.js`)**
- 파일 항목에 🤖 AI 분석 버튼 추가 (PDF/이미지만 활성화)
- 분석 요청 시 `fileName` 함께 전송
- 분석 중 ⏳ 아이콘 표시 (`analyzingFileId` state)

**Frontend (`ChatWindow.js`)**
- `ai-summary` 메시지 타입 렌더링 분기 추가
- SAGE AI 헤더 + 분석 타입 태그 + 📎 파일명 표시
- 문서: 요약 텍스트 / 이미지: 라벨(한글) + 감지된 텍스트

### 2. WebSocket 재연결 로직 추가 (Feat)
- 기존: 연결이 끊기면 영구적으로 "연결 중..." 상태 → 새로고침해야만 복구
- 개선: `useWebSocket` 훅에 자동 재연결 로직 추가
  - Exponential backoff (1s → 2s → 4s → ... → 최대 30s)
  - 최대 재시도 횟수 10회 제한
  - 의도적 종료(채널 전환/언마운트) 시 재연결 방지 플래그
  - 중복 연결 시도 방지 lock
  - 탭 visibility 복귀 시 즉시 재연결

### 3. 배포 스크립트 안전화 (Refactor)
- `deploy.sh`에 `WSS_ENDPOINT` 환경변수 추가
- `update-function-configuration` 블록 제거 → 코드 업데이트 시 환경변수가 PLACEHOLDER로 덮어써지는 문제 방지
- 시크릿(JWT_SECRET_KEY, SALT)을 콘솔에서 안전하게 관리 가능

### 4. 테스트용 AI 기능 UI (Feat)
- `ResourceHub.js`: 파일 항목에 🤖 AI 분석 버튼 추가 (PDF/이미지만 활성화)
- `ChatWindow.js`: `ai-summary` 메시지 타입 렌더링
  - 문서 요약: Bedrock Claude Haiku 요약 결과
  - 이미지 분석: Rekognition 라벨/감지 텍스트 + Translate 한글화
- 프론트 담당자 분들 참고용으로 봐주세요. 디자인 보강이나 동작 변경 의견 환영합니다 🙏

## ✅ 체크리스트
- [x] `README.md`에 명시된 코딩 컨벤션 및 커밋 메시지 규칙을 준수했습니다.
- [x] 관련 없는 코드나 불필요한 주석을 포함하지 않았습니다.
- [x] 작업할 브랜치(`dev`)의 최신 상태를 pull 받아 충돌이 없는 것을 확인했습니다.
- [x] (Backend) 람다 함수나 DB 스키마 변경 시 로컬/테스트 환경에서 검증을 완료했습니다.
  - aiRouter Lambda: CloudShell에서 `./deploy.sh`로 배포 후 PDF/이미지 분석 정상 동작 확인 ✅
  - WebSocket 재연결: 로컬에서 DevTools Offline 토글 / 탭 백그라운드 전환으로 검증 완료 ✅

## 💬 리뷰어에게

- 리소스 허브의 🤖 AI 분석 버튼과 채팅창의 SAGE AI 메시지 렌더링은 일단 **테스트용 기본 디자인**으로 만들어뒀습니다. 디자인 시스템에 맞게 보강 가능하니 의견 주세요.
- ai-summary 박스 스타일은 `ChatWindow.js` 내부에 인라인 스타일로 임시 작성됨 → CSS 파일로 분리하면 더 좋을 듯합니다.
- 헤더의 📎 아이콘과 파일명 표시 위치/스타일도 자유롭게 조정 가능합니다.
- `deploy.sh` 변경으로 코드 업데이트 시 환경변수가 보존됩니다. 새 Lambda 추가하실 때만 `create-function` 분기에서 PLACEHOLDER가 들어가니 콘솔에서 즉시 보정 부탁드립니다.
- AI 분석 진행 상태 표시 (1~2분 대기 동안 사용자 피드백) 고려 필요