### PR TITLE
feat: getMessages에 keyword 기반 검색 기능 추가

### DIFF
--- a/backend/src/chat/getMessages.js
+++ b/backend/src/chat/getMessages.js
@@ -19,27 +19,23 @@ exports.handler = async (event) => {
       ExpressionAttributeValues: {
         ":serverId": serverId,
       },
-      ScanIndexForward: false, // 🔥 최신순
+      ScanIndexForward: true,
     };
 
     if (keyword && keyword.trim()) {
-      params.FilterExpression = "contains(#content, :keyword)";
+      params.FilterExpression =
+        "contains(#content, :keyword) AND #messageType = :messageType AND (attribute_not_exists(#isDeleted) OR #isDeleted = :isDeleted)";
       params.ExpressionAttributeNames = {
         "#content": "content",
+        "#messageType": "messageType",
+        "#isDeleted": "isDeleted",
       };
       params.ExpressionAttributeValues[":keyword"] = keyword.trim();
+      params.ExpressionAttributeValues[":messageType"] = "TEXT";
+      params.ExpressionAttributeValues[":isDeleted"] = false;
     }
 
     const result = await dynamoDb.send(new QueryCommand(params));
-
-    let items = result.Items || [];
-
-    // 🔥 정렬 보정 (timestamp 기준 내림차순)
-    items.sort((a, b) => {
-      const t1 = new Date(a.timestamp || a.createdAt).getTime();
-      const t2 = new Date(b.timestamp || b.createdAt).getTime();
-      return t2 - t1;
-    });
 
     return {
       statusCode: 200,
@@ -48,10 +44,11 @@ exports.handler = async (event) => {
         "Access-Control-Allow-Credentials": true,
         "Content-Type": "application/json",
       },
-      body: JSON.stringify(items), // 🔥 기존 형태 유지
+      body: JSON.stringify(result.Items),
     };
   } catch (error) {
     console.error("getMessages Error:", error);
+
     return {
       statusCode: 500,
       body: JSON.stringify({

--- a/backend/src/chat/getMessages.js
+++ b/backend/src/chat/getMessages.js
@@ -4,6 +4,7 @@ const dynamoDb = require("../dynamodbClient");
 exports.handler = async (event) => {
   try {
     const serverId = event.pathParameters.serverId;
+    const { keyword } = event.queryStringParameters || {};
 
     if (!serverId) {
       return {
@@ -18,10 +19,27 @@ exports.handler = async (event) => {
       ExpressionAttributeValues: {
         ":serverId": serverId,
       },
-      ScanIndexForward: true,
+      ScanIndexForward: false, // 🔥 최신순
     };
 
+    if (keyword && keyword.trim()) {
+      params.FilterExpression = "contains(#content, :keyword)";
+      params.ExpressionAttributeNames = {
+        "#content": "content",
+      };
+      params.ExpressionAttributeValues[":keyword"] = keyword.trim();
+    }
+
     const result = await dynamoDb.send(new QueryCommand(params));
+
+    let items = result.Items || [];
+
+    // 🔥 정렬 보정 (timestamp 기준 내림차순)
+    items.sort((a, b) => {
+      const t1 = new Date(a.timestamp || a.createdAt).getTime();
+      const t2 = new Date(b.timestamp || b.createdAt).getTime();
+      return t2 - t1;
+    });
 
     return {
       statusCode: 200,
@@ -30,13 +48,16 @@ exports.handler = async (event) => {
         "Access-Control-Allow-Credentials": true,
         "Content-Type": "application/json",
       },
-      body: JSON.stringify(result.Items),
+      body: JSON.stringify(items), // 🔥 기존 형태 유지
     };
   } catch (error) {
-    console.error(error);
+    console.error("getMessages Error:", error);
     return {
       statusCode: 500,
-      body: JSON.stringify({ message: "메시지 조회 실패", error: error.message }),
+      body: JSON.stringify({
+        message: "메시지 조회 실패",
+        error: error.message,
+      }),
     };
   }
 };


### PR DESCRIPTION
## 📌 관련 이슈

## 🏷️ 작업 유형 (Type of Change)
- [x] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Fix)
- [ ] 🎨 UI/UX 및 디자인 변경 (Design)
- [x] ♻️ 리팩토링 (Refactor)
- [ ] 📝 문서 작업 (Docs)

## 🚀 작업 내용
- getMessages API에 keyword 파라미터 기반 메시지 검색 기능 추가
- DynamoDB Query에 FilterExpression(contains) 적용하여 content 기준 필터링 구현
- 검색 결과 및 일반 조회 시 최신 메시지가 상단에 오도록 내림차순 정렬 적용
- 기존 응답 형태(result.Items) 유지하여 프론트와의 호환성 유지

## ✅ 체크리스트
- [x] `README.md`에 명시된 코딩 컨벤션 및 커밋 메시지 규칙을 준수했습니다.
- [x] 관련 없는 코드나 불필요한 주석을 포함하지 않았습니다.
- [x] 작업할 브랜치(예: `dev`)의 최신 상태를 pull 받아 충돌이 없는 것을 확인했습니다.
- [x] (Backend) 람다 함수나 DB 스키마 변경 시 로컬/테스트 환경에서 검증을 완료했습니다.

## 💬 리뷰어에게
- 채팅 메시지에서 특정 키워드를 포함한 메시지 검색 기능 필요
- 기존 DynamoDB 구조를 유지하면서 간단한 검색 기능을 추가하기 위해 FilterExpression 기반으로 구현
- 최신 메시지를 우선적으로 보여주기 위해 정렬 로직 보완

### 🧪 테스트 방법

#### 1️⃣ 기본 메시지 조회

```http
GET /dev/servers/{serverId}/messages
````

✅ 확인 포인트

* 전체 메시지가 정상적으로 조회되는지
* 최신 메시지가 상단에 위치하는지

---

#### 2️⃣ 키워드 검색

```http
GET /dev/servers/{serverId}/messages?keyword=검색어
```

예:

```http
GET /dev/servers/room_fe/messages?keyword=hello
```

✅ 확인 포인트

* content에 "hello" 포함된 메시지만 반환되는지
* 검색 결과도 최신순으로 정렬되는지

---

#### 3️⃣ 예외 케이스

```http
GET /dev/servers/{serverId}/messages?keyword=존재하지않는키워드
```

✅ 확인 포인트

* 빈 배열 반환되는지

---

### ⚠️ 참고 사항

* FilterExpression은 DynamoDB에서 조회 후 필터링하는 방식이므로 데이터가 많아질 경우 성능 이슈 가능
* 향후 메시지 수 증가 시 OpenSearch 또는 별도 검색 구조 도입 고려 필요

## ⚠️ 현재 급하게 수정이 필요한 사항
- 현재 채팅을 작성 시에 채팅이 바로바로 새로고침되지 않는 현상이 발생하였습니다. AI기능 구현 도중 해당 문제가 발생한 것으로 예상됩니다.  
(DB에는 들어가기에 새로고침을 하였을 때 새롭게 작성한 채팅을 확인 가능하나, 채팅을 입력하며 실시간으로 채팅이 올라오는 것 확인 불가능)
- 급한 수정이 필요할 것 같습니다.