### PR TITLE
Refactor: 백엔드 CORS 헤더를 HEADERS 유틸로 일관성 통일

### DIFF
--- a/backend/deploy.sh
+++ b/backend/deploy.sh
@@ -12,7 +12,7 @@ REGION="us-east-1"
 ROLE_ARN="arn:aws:iam::269578498605:role/SafeRole-inhatc-team3"
 S3_BUCKET="inhatc-team3-2-deployments"
 S3_KEY="lambda-deploy.zip"
-RUNTIME="nodejs18.x"
+RUNTIME="nodejs20.x"
 TIMEOUT=30
 MEMORY=512
 

--- a/backend/src/ai/aiRouter.js
+++ b/backend/src/ai/aiRouter.js
@@ -3,16 +3,16 @@ const { RekognitionClient, DetectLabelsCommand, DetectTextCommand } = require("@
 const { TranslateClient, TranslateTextCommand } = require("@aws-sdk/client-translate");
 const { BedrockRuntimeClient, InvokeModelCommand } = require("@aws-sdk/client-bedrock-runtime");
 
-// [추가] DynamoDB, API Gateway WSS, UUID 모듈 임포트
 const { PutCommand, QueryCommand } = require("@aws-sdk/lib-dynamodb");
 const { ApiGatewayManagementApiClient, PostToConnectionCommand } = require("@aws-sdk/client-apigatewaymanagementapi");
 const { v4: uuidv4 } = require("uuid");
-const dynamoDb = require("../dynamodbClient"); // 작성해두신 공통 DB 클라이언트
+const dynamoDb = require("../dynamodbClient");
+const { HEADERS } = require("../utils/response");
 
 const REGION = process.env.REGION || "us-east-1";
 const RESOURCES_BUCKET = process.env.RESOURCES_BUCKET;
 
-// [추가] DB 테이블명 및 웹소켓 엔드포인트 환경변수
+// DB 테이블명 및 웹소켓 엔드포인트 환경변수
 const MESSAGES_TABLE = process.env.MESSAGES_TABLE;
 const CONNECTIONS_TABLE = process.env.CONNECTIONS_TABLE;
 const WSS_ENDPOINT = process.env.WSS_ENDPOINT; // HTTP 핸들러이므로 환경변수로 주입받아야 합니다.
@@ -65,7 +65,7 @@ exports.handler = async (event) => {
     if (!s3ObjectKey || !fileType) {
       return {
         statusCode: 400,
-        headers: { "Access-Control-Allow-Origin": "*" },
+        headers: HEADERS,
         body: JSON.stringify({ message: "s3ObjectKey, fileType은 필수입니다." }),
       };
     }
@@ -181,10 +181,9 @@ exports.handler = async (event) => {
       }
     }
 
-    // HTTP 응답 (REST를 호출한 클라이언트에게 완료되었음을 알림)
     return {
       statusCode: 200,
-      headers: { "Access-Control-Allow-Origin": "*" },
+      headers: HEADERS,
       body: JSON.stringify({
         message: "AI 분석 완료 및 채팅방 전송 성공",
         serverId: serverId || null,
@@ -195,7 +194,7 @@ exports.handler = async (event) => {
     console.error("AI Router Error:", error);
     return {
       statusCode: 500,
-      headers: { "Access-Control-Allow-Origin": "*" },
+      headers: HEADERS,
       body: JSON.stringify({ message: "AI 분석 실패", error: error.message }),
     };
   }

--- a/backend/src/auth/tokenRefresh.js
+++ b/backend/src/auth/tokenRefresh.js
@@ -1,9 +1,5 @@
 const { validateRefreshTokenAndGenerateAccessToken } = require("../utils");
-
-const HEADERS = {
-  "Access-Control-Allow-Origin":      "*",
-  "Access-Control-Allow-Credentials": true,
-};
+const { HEADERS } = require("../utils/response");
 
 // =========================
 // Access Token 재발급

--- a/backend/src/chat/getMessages.js
+++ b/backend/src/chat/getMessages.js
@@ -1,5 +1,6 @@
 const { QueryCommand } = require("@aws-sdk/lib-dynamodb");
 const dynamoDb = require("../dynamodbClient");
+const { HEADERS } = require("../utils/response");
 
 exports.handler = async (event) => {
   try {
@@ -8,6 +9,7 @@ exports.handler = async (event) => {
     if (!serverId) {
       return {
         statusCode: 400,
+        headers: HEADERS,
         body: JSON.stringify({ message: "serverId가 필요합니다." }),
       };
     }
@@ -25,17 +27,14 @@ exports.handler = async (event) => {
 
     return {
       statusCode: 200,
-      headers: {
-        "Access-Control-Allow-Origin": "*",
-        "Access-Control-Allow-Credentials": true,
-        "Content-Type": "application/json",
-      },
+      headers: HEADERS,
       body: JSON.stringify(result.Items),
     };
   } catch (error) {
     console.error(error);
     return {
       statusCode: 500,
+      headers: HEADERS,
       body: JSON.stringify({ message: "메시지 조회 실패", error: error.message }),
     };
   }

--- a/backend/src/resources/deleteFile.js
+++ b/backend/src/resources/deleteFile.js
@@ -2,6 +2,7 @@ const { GetCommand, UpdateCommand } = require("@aws-sdk/lib-dynamodb");
 const { S3Client, DeleteObjectCommand } = require("@aws-sdk/client-s3");
 const dynamoDb = require("../dynamodbClient");
 const { verifyAccessToken } = require("../utils");
+const { HEADERS } = require("../utils/response");
 
 const SERVERS_TABLE = process.env.SERVERS_TABLE;
 const RESOURCES_BUCKET = process.env.RESOURCES_BUCKET;
@@ -11,7 +12,11 @@ exports.handler = async (event) => {
   try {
     const auth = verifyAccessToken(event.headers?.Authorization || event.headers?.authorization);
     if (auth.error) {
-      return { statusCode: 401, headers: { "Access-Control-Allow-Origin": "*" }, body: JSON.stringify({ message: auth.error }) };
+      return { 
+        statusCode: 401, 
+        headers: HEADERS, 
+        body: JSON.stringify({ message: auth.error }) 
+      };
     }
 
     const { serverId, fileId } = event.pathParameters || {};
@@ -25,11 +30,23 @@ exports.handler = async (event) => {
     const files = serverData?.files || [];
     const targetFile = files.find((f) => f.fileId === fileId);
 
-    if (!targetFile) return { statusCode: 404, headers: { "Access-Control-Allow-Origin": "*" }, body: JSON.stringify({ message: "파일 없음" }) };
+    if (!targetFile) {
+      return { 
+        statusCode: 404, 
+        headers: HEADERS, 
+        body: JSON.stringify({ 
+          message: "파일 없음" 
+        }) 
+      };
+    }
 
     // 권한 체크
     if (targetFile.uploadedBy !== auth.userId && serverData.hostId !== auth.userId) {
-      return { statusCode: 403, headers: { "Access-Control-Allow-Origin": "*" }, body: JSON.stringify({ message: "권한 없음" }) };
+      return { 
+        statusCode: 403, 
+        headers: HEADERS, 
+        body: JSON.stringify({ message: "권한 없음" }) 
+      };
     }
 
     // S3 실제 객체 삭제
@@ -50,8 +67,16 @@ exports.handler = async (event) => {
       ExpressionAttributeValues: { ":updatedFiles": updatedFiles },
     }));
 
-    return { statusCode: 200, headers: { "Access-Control-Allow-Origin": "*" }, body: JSON.stringify({ message: "삭제 완료" }) };
+    return { 
+      statusCode: 200, 
+      headers: HEADERS,
+      body: JSON.stringify({ message: "삭제 완료" }) 
+    };
   } catch (error) {
-    return { statusCode: 500, headers: { "Access-Control-Allow-Origin": "*" }, body: JSON.stringify({ error: error.message }) };
+    return { 
+      statusCode: 500, 
+      headers: HEADERS, 
+      body: JSON.stringify({ error: error.message }) 
+    };
   }
 };

--- a/backend/src/resources/deleteLink.js
+++ b/backend/src/resources/deleteLink.js
@@ -1,6 +1,7 @@
 const { GetCommand, UpdateCommand } = require("@aws-sdk/lib-dynamodb");
 const dynamoDb = require("../dynamodbClient");
 const { verifyAccessToken } = require("../utils");
+const { HEADERS } = require("../utils/response");
 
 const SERVERS_TABLE = process.env.SERVERS_TABLE;
 
@@ -8,7 +9,11 @@ exports.handler = async (event) => {
   try {
     const auth = verifyAccessToken(event.headers?.Authorization || event.headers?.authorization);
     if (auth.error) {
-      return { statusCode: 401, headers: { "Access-Control-Allow-Origin": "*" }, body: JSON.stringify({ message: auth.error }) };
+      return {
+        statusCode: 401, 
+        headers: HEADERS,
+        body: JSON.stringify({ message: auth.error }) 
+      };
     }
 
     const { serverId, linkId } = event.pathParameters || {};
@@ -19,15 +24,29 @@ exports.handler = async (event) => {
     }));
 
     const serverData = getResult.Item;
-    if (!serverData) return { statusCode: 404, headers: { "Access-Control-Allow-Origin": "*" }, body: JSON.stringify({ message: "서버 없음" }) };
+    if (!serverData) return {
+      statusCode: 404, 
+      headers: HEADERS,
+      body: JSON.stringify({ message: "서버 없음" }) 
+    };
 
     const links = serverData.links || [];
     const targetLink = links.find((l) => l.linkId === linkId);
-    if (!targetLink) return { statusCode: 404, headers: { "Access-Control-Allow-Origin": "*" }, body: JSON.stringify({ message: "링크 없음" }) };
+    if (!targetLink) {
+      return { 
+        statusCode: 404, 
+        headers: HEADERS,
+        body: JSON.stringify({ message: "링크 없음" }) 
+      };
+    }
 
     // 권한: 작성자 또는 방장만 삭제 가능
     if (targetLink.sharedBy !== auth.userId && serverData.hostId !== auth.userId) {
-      return { statusCode: 403, headers: { "Access-Control-Allow-Origin": "*" }, body: JSON.stringify({ message: "권한 없음" }) };
+      return { 
+        statusCode: 403, 
+        headers: HEADERS,
+        body: JSON.stringify({ message: "권한 없음" }) 
+      };
     }
 
     const updatedLinks = links.filter((l) => l.linkId !== linkId);
@@ -40,8 +59,16 @@ exports.handler = async (event) => {
       ExpressionAttributeValues: { ":updatedLinks": updatedLinks },
     }));
 
-    return { statusCode: 200, headers: { "Access-Control-Allow-Origin": "*" }, body: JSON.stringify({ message: "삭제 완료" }) };
+    return { 
+      statusCode: 200, 
+      headers: HEADERS,
+      body: JSON.stringify({ message: "삭제 완료" })
+    };
   } catch (error) {
-    return { statusCode: 500, headers: { "Access-Control-Allow-Origin": "*" }, body: JSON.stringify({ error: error.message }) };
+    return { 
+      statusCode: 500, 
+      headers: HEADERS,
+      body: JSON.stringify({ error: error.message }) 
+    };
   }
 };

--- a/backend/src/resources/getUploadUrl.js
+++ b/backend/src/resources/getUploadUrl.js
@@ -1,6 +1,7 @@
 const { S3Client, PutObjectCommand } = require("@aws-sdk/client-s3");
 const { getSignedUrl } = require("@aws-sdk/s3-request-presigner");
 const { v4: uuidv4 } = require("uuid");
+const { HEADERS } = require("../utils/response");
 
 const s3Client = new S3Client({ region: process.env.AWS_REGION || "us-east-1" });
 
@@ -66,7 +67,7 @@ exports.handler = async (event) => {
     if (!fileName || !fileType) {
       return {
         statusCode: 400,
-        headers: { "Access-Control-Allow-Origin": "*" },
+        headers: HEADERS,
         body: JSON.stringify({ message: "fileName과 fileType 파라미터가 필요합니다." }),
       };
     }
@@ -76,7 +77,7 @@ exports.handler = async (event) => {
     if (!ALLOWED_EXTENSIONS.includes(fileExtension)) {
       return {
         statusCode: 400,
-        headers: { "Access-Control-Allow-Origin": "*" },
+        headers: HEADERS,
         body: JSON.stringify({
           message: `허용되지 않는 파일 확장자입니다: .${fileExtension}`,
           allowedExtensions: ALLOWED_EXTENSIONS,
@@ -88,7 +89,7 @@ exports.handler = async (event) => {
     if (!ALLOWED_TYPES[fileType]) {
       return {
         statusCode: 400,
-        headers: { "Access-Control-Allow-Origin": "*" },
+        headers: HEADERS,
         body: JSON.stringify({
           message: `허용되지 않는 파일 타입입니다: ${fileType}`,
         }),
@@ -110,10 +111,7 @@ exports.handler = async (event) => {
 
     return {
       statusCode: 200,
-      headers: {
-        "Access-Control-Allow-Origin": "*",
-        "Access-Control-Allow-Credentials": true,
-      },
+      headers: HEADERS,
       body: JSON.stringify({
         message: "업로드 URL 발급 성공",
         uploadUrl,
@@ -125,7 +123,7 @@ exports.handler = async (event) => {
     console.error("S3 URL 발급 에러:", error);
     return {
       statusCode: 500,
-      headers: { "Access-Control-Allow-Origin": "*" },
+      headers: HEADERS,
       body: JSON.stringify({ message: "URL 발급 실패", error: error.message }),
     };
   }

--- a/backend/src/resources/saveFileMetadata.js
+++ b/backend/src/resources/saveFileMetadata.js
@@ -3,6 +3,7 @@ const { S3Client, DeleteObjectCommand, HeadObjectCommand } = require("@aws-sdk/c
 const { v4: uuidv4 } = require("uuid");
 const dynamoDb = require("../dynamodbClient");
 const { verifyAccessToken } = require("../utils");
+const { HEADERS } = require("../utils/response");
 
 const SERVERS_TABLE = process.env.SERVERS_TABLE;
 const RESOURCES_BUCKET = process.env.RESOURCES_BUCKET;
@@ -12,7 +13,11 @@ exports.handler = async (event) => {
   try {
     const auth = verifyAccessToken(event.headers?.Authorization || event.headers?.authorization);
     if (auth.error) {
-      return { statusCode: 401, headers: { "Access-Control-Allow-Origin": "*" }, body: JSON.stringify({ message: auth.error }) };
+      return {
+        statusCode: 401, 
+        headers: HEADERS, 
+        body: JSON.stringify({ message: auth.error }) 
+      };
     }
 
     const { serverId } = event.pathParameters || {};
@@ -25,14 +30,28 @@ exports.handler = async (event) => {
       const { fileId } = body;
       const getResult = await dynamoDb.send(new GetCommand({ TableName: SERVERS_TABLE, Key: { serverId } }));
       const serverData = getResult.Item;
-      if (!serverData) return { statusCode: 404, headers: { "Access-Control-Allow-Origin": "*" }, body: JSON.stringify({ message: "서버 없음" }) };
+      if (!serverData) return { 
+        statusCode: 404, 
+        headers: HEADERS, 
+        body: JSON.stringify({ message: "서버 없음" }) 
+      };
 
       const files = serverData.files || [];
       const targetFile = files.find(f => f.fileId === fileId);
-      if (!targetFile) return { statusCode: 404, headers: { "Access-Control-Allow-Origin": "*" }, body: JSON.stringify({ message: "파일 없음" }) };
+      if (!targetFile) {
+        return { 
+          statusCode: 404, 
+          headers: HEADERS, 
+          body: JSON.stringify({ message: "파일 없음" }) 
+        };
+      }
 
       if (targetFile.uploadedBy !== auth.userId && serverData.hostId !== auth.userId) {
-        return { statusCode: 403, headers: { "Access-Control-Allow-Origin": "*" }, body: JSON.stringify({ message: "권한 없음" }) };
+        return { 
+          statusCode: 403, 
+          headers: HEADERS, 
+          body: JSON.stringify({ message: "권한 없음" }) 
+        };
       }
 
       if (targetFile.s3ObjectKey) {
@@ -48,7 +67,11 @@ exports.handler = async (event) => {
         ExpressionAttributeNames: { "#files": "files" },
         ExpressionAttributeValues: { ":updatedFiles": updatedFiles }
       }));
-      return { statusCode: 200, headers: { "Access-Control-Allow-Origin": "*" }, body: JSON.stringify({ message: "파일 삭제 완료" }) };
+      return {
+        statusCode: 200, 
+        headers: HEADERS, 
+        body: JSON.stringify({ message: "파일 삭제 완료" }) 
+      };
     }
 
     // ──────────────────────────────────────────
@@ -56,7 +79,11 @@ exports.handler = async (event) => {
     // ──────────────────────────────────────────
     const { fileName, fileUrl, fileType, s3ObjectKey } = body;
     if (!serverId || !fileName || !fileUrl) {
-      return { statusCode: 400, headers: { "Access-Control-Allow-Origin": "*" }, body: JSON.stringify({ message: "필수값 누락" }) };
+      return {
+        statusCode: 400, 
+        headers: HEADERS,  
+        body: JSON.stringify({ message: "필수값 누락" }) 
+      };
     }
 
     // 파일 검증 로직
@@ -72,7 +99,7 @@ exports.handler = async (event) => {
         // 파일이 없으면 에러를 던져 DB 저장을 차단합니다.
         return { 
           statusCode: 400, 
-          headers: { "Access-Control-Allow-Origin": "*" }, 
+          headers: HEADERS, 
           body: JSON.stringify({ message: "S3에 파일이 존재하지 않거나 업로드가 완료되지 않았습니다." }) 
         };
       }
@@ -90,9 +117,17 @@ exports.handler = async (event) => {
       ExpressionAttributeValues: { ":newFile": [fileItem], ":empty": [] },
     }));
 
-    return { statusCode: 200, headers: { "Access-Control-Allow-Origin": "*" }, body: JSON.stringify({ message: "저장 완료", file: fileItem }) };
+    return { 
+      statusCode: 200, 
+      headers: HEADERS, 
+      body: JSON.stringify({ message: "저장 완료", file: fileItem }) 
+    };
 
   } catch (error) {
-    return { statusCode: 500, headers: { "Access-Control-Allow-Origin": "*" }, body: JSON.stringify({ error: error.message }) };
+    return { 
+      statusCode: 500, 
+      headers: HEADERS, 
+      body: JSON.stringify({ error: error.message }) 
+    };
   }
 };

--- a/backend/src/resources/saveLink.js
+++ b/backend/src/resources/saveLink.js
@@ -2,17 +2,14 @@ const { UpdateCommand, GetCommand } = require("@aws-sdk/lib-dynamodb");
 const { v4: uuidv4 } = require("uuid");
 const dynamoDb = require("../dynamodbClient");
 const { verifyAccessToken } = require("../utils");
-const { getLinkPreview } = require("../linkPreview");
+const { getLinkPreview } = require("./linkPreview");
+const { HEADERS } = require("../utils/response");
 
 const SERVERS_TABLE = process.env.SERVERS_TABLE;
 
-const headers = {
-  "Access-Control-Allow-Origin": "*",
-};
-
 const response = (statusCode, body) => ({
   statusCode,
-  headers,
+  headers: HEADERS,
   body: JSON.stringify(body),
 });
 

--- a/backend/src/servers/addChannel.js
+++ b/backend/src/servers/addChannel.js
@@ -1,6 +1,7 @@
 const { GetCommand, UpdateCommand } = require("@aws-sdk/lib-dynamodb");
 const { v4: uuidv4 } = require("uuid");
 const dynamoDb = require("../dynamodbClient");
+const { HEADERS } = require("../utils/response");
 
 exports.handler = async (event) => {
   try {
@@ -11,6 +12,7 @@ exports.handler = async (event) => {
     if (!name) {
       return {
         statusCode: 400,
+        headers: HEADERS,
         body: JSON.stringify({ message: "채널 이름은 필수입니다." }),
       };
     }
@@ -23,6 +25,7 @@ exports.handler = async (event) => {
     if (!serverData.Item) {
       return {
         statusCode: 404,
+        headers: HEADERS,
         body: JSON.stringify({ message: "서버를 찾을 수 없습니다." }),
       };
     }
@@ -46,16 +49,13 @@ exports.handler = async (event) => {
 
     return {
       statusCode: 200,
-      headers: {
-        "Access-Control-Allow-Origin": "*",
-        "Access-Control-Allow-Credentials": true,
-      },
+      headers: HEADERS,
       body: JSON.stringify({ message: "채널 추가 성공", channel: newChannel }),
     };
   } catch (error) {
     console.error(error);
     return {
-      statusCode: 500,
+      headers: HEADERS,
       body: JSON.stringify({ message: "채널 추가 실패", error: error.message }),
     };
   }

--- a/backend/src/servers/createServer.js
+++ b/backend/src/servers/createServer.js
@@ -2,6 +2,7 @@ const { PutCommand, GetCommand } = require("@aws-sdk/lib-dynamodb");
 const { v4: uuidv4 } = require("uuid");
 const dynamoDb = require("../dynamodbClient");
 const { verifyAccessToken } = require("../utils");
+const { HEADERS } = require("../utils/response");
 
 module.exports.handler = async (event) => {
   try {
@@ -72,11 +73,7 @@ module.exports.handler = async (event) => {
 
     return {
       statusCode: 200,
-      headers: {
-        "Access-Control-Allow-Origin": "*",
-        "Access-Control-Allow-Credentials": true,
-        "Content-Type": "application/json",
-      },
+      headers: HEADERS,
       body: JSON.stringify({
         message: "서버 생성 성공",
         serverId,
@@ -86,11 +83,7 @@ module.exports.handler = async (event) => {
     console.error(error);
     return {
       statusCode: 500,
-      headers: {
-        "Access-Control-Allow-Origin": "*",
-        "Access-Control-Allow-Credentials": true,
-        "Content-Type": "application/json",
-      },
+      headers: HEADERS,
       body: JSON.stringify({ message: "서버 생성 실패", error: error.message }),
     };
   }

--- a/backend/src/servers/deleteChannel.js
+++ b/backend/src/servers/deleteChannel.js
@@ -1,5 +1,6 @@
 const { GetCommand, UpdateCommand } = require("@aws-sdk/lib-dynamodb");
 const dynamoDb = require("../dynamodbClient");
+const { HEADERS } = require("../utils/response");
 
 exports.handler = async (event) => {
   try {
@@ -14,6 +15,7 @@ exports.handler = async (event) => {
     if (!serverData.Item || !serverData.Item.channels) {
       return {
         statusCode: 404,
+        headers: HEADERS,
         body: JSON.stringify({ message: "서버 또는 채널 정보를 찾을 수 없습니다." }),
       };
     }
@@ -24,10 +26,7 @@ exports.handler = async (event) => {
     if (targetChannel?.isDefault) {
       return {
         statusCode: 403,
-        headers: {
-          "Access-Control-Allow-Origin": "*",
-          "Access-Control-Allow-Credentials": true,
-        },
+        headers: HEADERS,
         body: JSON.stringify({ message: "기본 채널은 삭제할 수 없습니다." }),
       };
     }
@@ -45,16 +44,14 @@ const updatedChannels = currentChannels.filter((ch) => ch.chId !== chId);
 
     return {
       statusCode: 200,
-      headers: {
-        "Access-Control-Allow-Origin": "*",
-        "Access-Control-Allow-Credentials": true,
-      },
+      headers: HEADERS,
       body: JSON.stringify({ message: "채널 삭제 성공" }),
     };
   } catch (error) {
     console.error(error);
     return {
       statusCode: 500,
+      headers: HEADERS,
       body: JSON.stringify({ message: "채널 삭제 실패", error: error.message }),
     };
   }

--- a/backend/src/servers/deleteServer.js
+++ b/backend/src/servers/deleteServer.js
@@ -1,6 +1,7 @@
 const { GetCommand, DeleteCommand } = require("@aws-sdk/lib-dynamodb");
 const dynamoDb = require("../dynamodbClient");
 const { verifyAccessToken } = require("../utils");
+const { HEADERS } = require("../utils/response");
 
 exports.handler = async (event) => {
   try {
@@ -12,11 +13,7 @@ exports.handler = async (event) => {
     if (error || !userId) {
       return {
         statusCode: 401,
-        headers: { 
-          "Access-Control-Allow-Origin": "*",
-          "Access-Control-Allow-Credentials": true,
-          "Content-Type": "application/json" 
-        },
+        headers: HEADERS,
         body: JSON.stringify({ message: "인증이 필요합니다." }),
       };
     }
@@ -29,10 +26,7 @@ exports.handler = async (event) => {
     if (!serverResult.Item) {
       return {
         statusCode: 404,
-        headers: { 
-          "Access-Control-Allow-Origin": "*", 
-          "Content-Type": "application/json" 
-        },
+        headers: HEADERS,
         body: JSON.stringify({ message: "해당 서버를 찾을 수 없습니다." }),
       };
     }
@@ -40,10 +34,7 @@ exports.handler = async (event) => {
     if (serverResult.Item.hostId !== userId) {
       return {
         statusCode: 403,
-        headers: {
-          "Access-Control-Allow-Origin": "*", 
-          "Content-Type": "application/json" 
-        },
+        headers: HEADERS,
         body: JSON.stringify({ message: "서버 삭제는 호스트만 가능합니다." }),
       };
     }
@@ -78,14 +69,14 @@ exports.handler = async (event) => {
 
     return {
       statusCode: 200,
-      headers: { "Access-Control-Allow-Origin": "*", "Content-Type": "application/json" },
+      headers: HEADERS,
       body: JSON.stringify({ message: "서버 삭제 성공", serverId }),
     };
   } catch (error) {
     console.error("deleteServer Error:", error);
     return {
       statusCode: 500,
-      headers: { "Access-Control-Allow-Origin": "*", "Content-Type": "application/json" },
+      headers: HEADERS,
       body: JSON.stringify({ message: "서버 삭제 실패", error: error.message }),
     };
   }

--- a/backend/src/servers/getServerDetail.js
+++ b/backend/src/servers/getServerDetail.js
@@ -1,5 +1,6 @@
 const { GetCommand } = require("@aws-sdk/lib-dynamodb");
 const dynamoDb = require("../dynamodbClient");
+const { HEADERS } = require("../utils/response");
 
 exports.handler = async (event) => {
   try {
@@ -8,6 +9,7 @@ exports.handler = async (event) => {
     if (!serverId) {
       return {
         statusCode: 400,
+        headers: HEADERS,
         body: JSON.stringify({ message: "serverId가 필요합니다." }),
       };
     }
@@ -20,28 +22,21 @@ exports.handler = async (event) => {
     if (!result.Item) {
       return {
         statusCode: 404,
-        headers: {
-          "Access-Control-Allow-Origin": "*",
-          "Access-Control-Allow-Credentials": true,
-          "Content-Type": "application/json",
-        },
+        headers: HEADERS,
         body: JSON.stringify({ message: "해당 서버를 찾을 수 없습니다." }),
       };
     }
 
     return {
       statusCode: 200,
-      headers: {
-        "Access-Control-Allow-Origin": "*",
-        "Access-Control-Allow-Credentials": true,
-        "Content-Type": "application/json",
-      },
+      headers: HEADERS,
       body: JSON.stringify(result.Item),
     };
   } catch (error) {
     console.error(error);
     return {
       statusCode: 500,
+      headers: HEADERS,
       body: JSON.stringify({ message: "서버 상세 조회 실패", error: error.message }),
     };
   }

--- a/backend/src/servers/getServers.js
+++ b/backend/src/servers/getServers.js
@@ -1,5 +1,6 @@
 const { QueryCommand } = require("@aws-sdk/lib-dynamodb");
 const dynamoDb = require("../dynamodbClient");
+const { HEADERS } = require("../utils/response");
 
 exports.handler = async (event) => {
   try {
@@ -23,11 +24,7 @@ exports.handler = async (event) => {
 
     return {
       statusCode: 200,
-      headers: {
-        "Access-Control-Allow-Origin": "*",
-        "Access-Control-Allow-Credentials": true,
-        "Content-Type": "application/json",
-      },
+      headers: HEADERS,
       body: JSON.stringify({
         items: result.Items,
         lastKey: result.LastEvaluatedKey ? encodeURIComponent(JSON.stringify(result.LastEvaluatedKey)) : null,
@@ -37,6 +34,7 @@ exports.handler = async (event) => {
     console.error(error);
     return {
       statusCode: 500,
+      headers: HEADERS,
       body: JSON.stringify({ message: "서버 목록 조회 실패", error: error.message }),
     };
   }

--- a/backend/src/servers/joinServer.js
+++ b/backend/src/servers/joinServer.js
@@ -1,6 +1,7 @@
 const { GetCommand, PutCommand, UpdateCommand } = require("@aws-sdk/lib-dynamodb");
 const dynamoDb = require("../dynamodbClient");
 const { verifyAccessToken } = require("../utils");
+const { HEADERS } = require("../utils/response");
 
 exports.handler = async (event) => {
   try {
@@ -12,7 +13,7 @@ exports.handler = async (event) => {
     if (!userId) {
       return {
         statusCode: 401,
-        headers: { "Access-Control-Allow-Origin": "*", "Content-Type": "application/json" },
+        headers: HEADERS,
         body: JSON.stringify({ message: "인증이 필요합니다." }),
       };
     }
@@ -20,7 +21,7 @@ exports.handler = async (event) => {
     if (!serverId) {
       return {
         statusCode: 400,
-        headers: { "Access-Control-Allow-Origin": "*", "Content-Type": "application/json" },
+        headers: HEADERS,
         body: JSON.stringify({ message: "serverId가 필요합니다." }),
       };
     }
@@ -34,7 +35,7 @@ exports.handler = async (event) => {
     if (!serverResult.Item) {
       return {
         statusCode: 404,
-        headers: { "Access-Control-Allow-Origin": "*", "Content-Type": "application/json" },
+        headers: HEADERS,
         body: JSON.stringify({ message: "해당 서버를 찾을 수 없습니다." }),
       };
     }
@@ -48,7 +49,7 @@ exports.handler = async (event) => {
     if (membershipResult.Item) {
       return {
         statusCode: 200,
-        headers: { "Access-Control-Allow-Origin": "*", "Content-Type": "application/json" },
+        headers: HEADERS,
         body: JSON.stringify({
           message: "이미 참여 중인 서버입니다.",
           serverId,
@@ -63,7 +64,7 @@ exports.handler = async (event) => {
     if (currentCount >= maxCapacity) {
       return {
         statusCode: 403,
-        headers: { "Access-Control-Allow-Origin": "*", "Content-Type": "application/json" },
+        headers: HEADERS,
         body: JSON.stringify({ message: "서버 정원이 가득 찼습니다." }),
       };
     }
@@ -75,7 +76,7 @@ exports.handler = async (event) => {
       if (!body.serverPassword || body.serverPassword !== serverResult.Item.serverPassword) {
         return {
           statusCode: 403,
-          headers: { "Access-Control-Allow-Origin": "*", "Content-Type": "application/json" },
+          headers: HEADERS,
           body: JSON.stringify({ message: "비밀번호가 올바르지 않습니다." }),
         };
       }
@@ -111,14 +112,14 @@ exports.handler = async (event) => {
 
     return {
       statusCode: 200,
-      headers: { "Access-Control-Allow-Origin": "*", "Content-Type": "application/json" },
+      headers: HEADERS,
       body: JSON.stringify({ message: "서버 참여 성공", serverId, alreadyMember: false }),
     };
   } catch (error) {
     console.error("joinServer Error:", error);
     return {
       statusCode: 500,
-      headers: { "Access-Control-Allow-Origin": "*", "Content-Type": "application/json" },
+      headers: HEADERS,
       body: JSON.stringify({ message: "서버 참여 실패", error: error.message }),
     };
   }

--- a/backend/src/servers/leaveServer.js
+++ b/backend/src/servers/leaveServer.js
@@ -1,6 +1,7 @@
 const { GetCommand, DeleteCommand, UpdateCommand } = require("@aws-sdk/lib-dynamodb");
 const dynamoDb = require("../dynamodbClient");
 const { verifyAccessToken } = require("../utils");
+const { HEADERS } = require("../utils/response");
 
 exports.handler = async (event) => {
   try {
@@ -11,7 +12,7 @@ exports.handler = async (event) => {
     if (!userId) {
       return {
         statusCode: 401,
-        headers: { "Access-Control-Allow-Origin": "*", "Content-Type": "application/json" },
+        headers: HEADERS,
         body: JSON.stringify({ message: "인증이 필요합니다." }),
       };
     }
@@ -25,7 +26,7 @@ exports.handler = async (event) => {
     if (!serverResult.Item) {
       return {
         statusCode: 404,
-        headers: { "Access-Control-Allow-Origin": "*", "Content-Type": "application/json" },
+        headers: HEADERS,
         body: JSON.stringify({ message: "해당 서버를 찾을 수 없습니다." }),
       };
     }
@@ -34,7 +35,7 @@ exports.handler = async (event) => {
     if (serverResult.Item.hostId === userId) {
       return {
         statusCode: 403,
-        headers: { "Access-Control-Allow-Origin": "*", "Content-Type": "application/json" },
+        headers: HEADERS,
         body: JSON.stringify({ message: "방장은 서버를 나갈 수 없습니다. 서버를 삭제해주세요." }),
       };
     }
@@ -61,14 +62,14 @@ exports.handler = async (event) => {
 
     return {
       statusCode: 200,
-      headers: { "Access-Control-Allow-Origin": "*", "Content-Type": "application/json" },
+      headers: HEADERS,
       body: JSON.stringify({ message: "서버에서 나갔습니다.", serverId }),
     };
   } catch (error) {
     console.error("leaveServer Error:", error);
     return {
       statusCode: 500,
-      headers: { "Access-Control-Allow-Origin": "*", "Content-Type": "application/json" },
+      headers: HEADERS,
       body: JSON.stringify({ message: "서버 나가기 실패", error: error.message }),
     };
   }

--- a/backend/src/servers/updateChannel.js
+++ b/backend/src/servers/updateChannel.js
@@ -1,5 +1,6 @@
 const { GetCommand, UpdateCommand } = require("@aws-sdk/lib-dynamodb");
 const dynamoDb = require("../dynamodbClient");
+const { HEADERS } = require("../utils/response");
 
 exports.handler = async (event) => {
   try {
@@ -14,7 +15,7 @@ exports.handler = async (event) => {
     if (!serverResult.Item || !serverResult.Item.channels) {
       return {
         statusCode: 404,
-        headers: { "Access-Control-Allow-Origin": "*", "Content-Type": "application/json" },
+        headers: HEADERS,
         body: JSON.stringify({ message: "서버 또는 채널을 찾을 수 없습니다." }),
       };
     }
@@ -25,7 +26,7 @@ exports.handler = async (event) => {
     if (channelIndex === -1) {
       return {
         statusCode: 404,
-        headers: { "Access-Control-Allow-Origin": "*", "Content-Type": "application/json" },
+        headers: HEADERS,
         body: JSON.stringify({ message: "해당 채널을 찾을 수 없습니다." }),
       };
     }
@@ -49,14 +50,14 @@ exports.handler = async (event) => {
 
     return {
       statusCode: 200,
-      headers: { "Access-Control-Allow-Origin": "*", "Content-Type": "application/json" },
+      headers: HEADERS,
       body: JSON.stringify({ message: "채널 수정 완료", channel: updatedChannel }),
     };
   } catch (error) {
     console.error("updateChannel Error:", error);
     return {
       statusCode: 500,
-      headers: { "Access-Control-Allow-Origin": "*", "Content-Type": "application/json" },
+      headers: HEADERS,
       body: JSON.stringify({ message: "채널 수정 실패", error: error.message }),
     };
   }

--- a/backend/src/servers/updateServer.js
+++ b/backend/src/servers/updateServer.js
@@ -1,6 +1,7 @@
 const { GetCommand, UpdateCommand } = require("@aws-sdk/lib-dynamodb");
 const dynamoDb = require("../dynamodbClient");
 const { verifyAccessToken } = require("../utils");
+const { HEADERS } = require("../utils/response");
 
 exports.handler = async (event) => {
   try {
@@ -11,7 +12,7 @@ exports.handler = async (event) => {
     if (!userId) {
       return {
         statusCode: 401,
-        headers: { "Access-Control-Allow-Origin": "*", "Content-Type": "application/json" },
+        headers: HEADERS,
         body: JSON.stringify({ message: "인증이 필요합니다." }),
       };
     }
@@ -24,7 +25,7 @@ exports.handler = async (event) => {
     if (!serverResult.Item) {
       return {
         statusCode: 404,
-        headers: { "Access-Control-Allow-Origin": "*", "Content-Type": "application/json" },
+        headers: HEADERS,
         body: JSON.stringify({ message: "해당 서버를 찾을 수 없습니다." }),
       };
     }
@@ -32,7 +33,7 @@ exports.handler = async (event) => {
     if (serverResult.Item.hostId !== userId) {
       return {
         statusCode: 403,
-        headers: { "Access-Control-Allow-Origin": "*", "Content-Type": "application/json" },
+        headers: HEADERS,
         body: JSON.stringify({ message: "방장만 서버 설정을 수정할 수 있습니다." }),
       };
     }
@@ -69,7 +70,7 @@ exports.handler = async (event) => {
     if (updateExpressions.length === 0) {
       return {
         statusCode: 400,
-        headers: { "Access-Control-Allow-Origin": "*", "Content-Type": "application/json" },
+        headers: HEADERS,
         body: JSON.stringify({ message: "수정할 항목이 없습니다." }),
       };
     }
@@ -90,14 +91,14 @@ exports.handler = async (event) => {
 
     return {
       statusCode: 200,
-      headers: { "Access-Control-Allow-Origin": "*", "Content-Type": "application/json" },
+      headers: HEADERS,
       body: JSON.stringify({ message: "서버 설정 수정 완료", room: updated.Item }),
     };
   } catch (error) {
     console.error("updateServer Error:", error);
     return {
       statusCode: 500,
-      headers: { "Access-Control-Allow-Origin": "*", "Content-Type": "application/json" },
+      headers: HEADERS,
       body: JSON.stringify({ message: "서버 설정 수정 실패", error: error.message }),
     };
   }


### PR DESCRIPTION
## 📌 관련 이슈
없음 (코드 품질 개선 + 잠재 버그 수정)

## 🏷️ 작업 유형 (Type of Change)
- [ ] ✨ 기능 추가 (Feature)
- [x] 🐛 버그 수정 (Fix)
- [ ] 🎨 UI/UX 및 디자인 변경 (Design)
- [x] ♻️ 리팩토링 (Refactor)
- [ ] 📝 문서 작업 (Docs)

## 🚀 작업 내용

### 1. CORS 헤더 일관성 통일 (Refactor)
백엔드 18개 Lambda 핸들러가 CORS 헤더를 인라인으로 박아두어 패턴이 난립했습니다.
- 일부 응답: `Access-Control-Allow-Origin`만
- 일부 응답: `Origin + Credentials`
- 일부 응답: `Origin + Credentials + Content-Type`
- 일부 400/500 에러 응답: 헤더 자체 누락 → CORS 깨짐 시한폭탄

모든 응답을 `backend/src/utils/response.js`의 `HEADERS` 유틸로 통일했습니다.

**변경 파일 (18개)**
- auth: `tokenRefresh.js`
- chat: `getMessages.js`
- servers: `addChannel.js`, `createServer.js`, `getServers.js`, `getServerDetail.js`, `joinServer.js`, `leaveServer.js`, `deleteServer.js`, `updateServer.js`, `updateChannel.js`, `deleteChannel.js`
- resources: `getUploadUrl.js`, `saveFileMetadata.js`, `saveLink.js`, `deleteFile.js`, `deleteLink.js`
- ai: `aiRouter.js`

### 2. saveLink linkPreview require 경로 버그 수정 (Fix)
`saveLink.js`의 require 경로 오류로 링크 추가 기능이 항상 `Runtime.ImportModuleError`로 깨지고 있던 것을 발견하여 수정.
- before: `require("../linkPreview")` → `backend/src/linkPreview.js` (존재하지 않음)
- after: `require("./linkPreview")` → `backend/src/resources/linkPreview.js`

### 3. deploy.sh 환경변수 안전화 (Refactor)
- `WSS_ENDPOINT` 추가
- `update-function-configuration` 블록 제거 → 코드 업데이트 시 환경변수가 PLACEHOLDER로 덮어써지는 문제 방지

## ✅ 체크리스트
- [x] `README.md`에 명시된 코딩 컨벤션 및 커밋 메시지 규칙을 준수했습니다.
- [x] 관련 없는 코드나 불필요한 주석을 포함하지 않았습니다.
- [x] 작업할 브랜치(`dev`)의 최신 상태를 pull 받아 충돌이 없는 것을 확인했습니다.
- [x] (Backend) 람다 함수나 DB 스키마 변경 시 로컬/테스트 환경에서 검증을 완료했습니다.
  - CloudShell에서 `./deploy.sh`로 배포 후 통합 테스트 완료
  - 검증: 로그인, 서버 CRUD, 채널 CRUD, 파일/링크/AI 분석 모두 정상

## 💬 리뷰어에게

**diff 양 안내**
- 18개 파일이 변경되어 diff가 길어 보이지만, 패턴이 동일합니다:
  `headers: { "Access-Control-Allow-Origin": "*", ... }` → `headers: HEADERS`
- 로직 변경 없음. 응답 헤더만 통일

**별도 운영 작업 (PR 외)**
- 검증 중 Lambda 런타임 호환성 이슈 발견 (Node 18.20.x undici 버그)
- 19개 Lambda를 nodejs18.x → nodejs20.x로 일괄 업그레이드 완료
- deploy.sh의 RUNTIME 변수도 nodejs20.x로 수정함

**향후 운영 효과**
- `ALLOWED_ORIGIN` 환경변수를 특정 도메인으로 바꾸면 모든 응답에 자동 적용
- 새 핸들러 추가 시에도 `HEADERS` 유틸 사용으로 패턴 강제