### PR TITLE
Feat: 채널 내 실시간 동기화 강화 (AI 진행 상태, 파일/링크 공유, 온라인 표시)

### DIFF
--- a/backend/src/ai/aiRouter.js
+++ b/backend/src/ai/aiRouter.js
@@ -60,7 +60,7 @@ async function summarizeWithBedrock(text) {
 exports.handler = async (event) => {
   try {
     const body = JSON.parse(event.body || "{}");
-    const { s3ObjectKey, fileType, serverId, fileName } = body;
+    const { s3ObjectKey, fileType, serverId, fileName, requestId } = body;
 
     if (!s3ObjectKey || !fileType) {
       return {
@@ -139,6 +139,7 @@ exports.handler = async (event) => {
         messageType: "ai-summary",     // 프론트엔드 CSS 트리거용 타입
         content: JSON.stringify(result), // 결과 객체를 문자열로 담음 (프론트에서 JSON.parse)
         createdAt,
+        ...(requestId && { aiRequestId: requestId }),
       };
 
       // 1. Messages 테이블에 저장

--- a/backend/src/chat/chatHandler.js
+++ b/backend/src/chat/chatHandler.js
@@ -3,6 +3,7 @@ const {
   UpdateCommand,
   QueryCommand,
   DeleteCommand,
+  GetCommand,
 } = require("@aws-sdk/lib-dynamodb");
 const {
   ApiGatewayManagementApiClient,
@@ -69,14 +70,48 @@ async function onConnect(event) {
 // =========================
 async function onDisconnect(event) {
   const connectionId = event.requestContext.connectionId;
+  const domain = event.requestContext.domainName;
+  const stage = event.requestContext.stage;
+  const apigw = getApigwClient(domain, stage);
 
-  // Delete 대신 논리적으로 방에서 제외
+  // 1. 끊긴 connection의 serverId, userId 조회 (브로드캐스트용)
+  const connResult = await dynamoDb.send(new GetCommand({
+    TableName: CONNECTIONS_TABLE,
+    Key: { connectionId },
+  })).catch(() => null);
+
+  const serverId = connResult?.Item?.serverId;
+  const userId = connResult?.Item?.userId;
+
+  // 2. CONNECTIONS 테이블 업데이트 (DISCONNECTED)
   await dynamoDb.send(new UpdateCommand({
     TableName: CONNECTIONS_TABLE,
-    Key:       { connectionId },
+    Key: { connectionId },
     UpdateExpression: "SET serverId = :none",
     ExpressionAttributeValues: { ":none": "DISCONNECTED" }
   })).catch(() => {});
+
+  // 3. 같은 서버 다른 접속자들에게 userLeft 브로드캐스트
+  if (serverId && serverId !== "DISCONNECTED" && userId) {
+    const response = await dynamoDb.send(new QueryCommand({
+      TableName: CONNECTIONS_TABLE,
+      IndexName: "serverId-index",
+      KeyConditionExpression: "serverId = :serverId",
+      ExpressionAttributeValues: { ":serverId": serverId },
+    }));
+    const connections = response.Items || [];
+
+    await Promise.all(
+      connections
+        .filter((c) => c.connectionId !== connectionId)
+        .map((conn) =>
+          sendToConnection(apigw, conn.connectionId, {
+            action: "userLeft",
+            data: { serverId, userId },
+          })
+        )
+    );
+  }
 
   return { statusCode: 200 };
 }
@@ -113,10 +148,14 @@ async function createServer(body) {
 // =========================
 // 방 입장
 // =========================
-async function joinServer(connectionId, body) {
+async function joinServer(connectionId, body, event) {
+  const domain = event.requestContext.domainName;
+  const stage = event.requestContext.stage;
+  const apigw = getApigwClient(domain, stage);
+
   const { serverId, userId } = body;
 
-  // 해당 connection에 serverId, userId 연결
+  // 1. 해당 connection에 serverId, userId 연결
   await dynamoDb.send(new UpdateCommand({
     TableName:                 CONNECTIONS_TABLE,
     Key:                       { connectionId },
@@ -124,13 +163,43 @@ async function joinServer(connectionId, body) {
     ExpressionAttributeValues: { ":r": serverId, ":u": userId },
   }));
 
-  // 방 인원 +1
+  // 2. 방 인원 +1
   await dynamoDb.send(new UpdateCommand({
     TableName:                 SERVERS_TABLE,
     Key:                       { serverId },
     UpdateExpression:          "SET currentCount = currentCount + :inc",
     ExpressionAttributeValues: { ":inc": 1 },
   }));
+
+  // 3. 같은 서버 모든 접속자 조회
+  const response = await dynamoDb.send(new QueryCommand({
+    TableName: CONNECTIONS_TABLE,
+    IndexName: "serverId-index",
+    KeyConditionExpression: "serverId = :serverId",
+    ExpressionAttributeValues: { ":serverId": serverId },
+  }));
+  const connections = response.Items || [];
+
+  // 4. 본인에게 현재 온라인 유저 ID 리스트 전송 (자기 포함)
+  const onlineUserIds = [...new Set(
+    connections.map((c) => c.userId).filter(Boolean)
+  )];
+  await sendToConnection(apigw, connectionId, {
+    action: "onlineMembers",
+    data: { serverId, onlineUserIds },
+  });
+
+  // 5. 다른 접속자들에게 userJoined 브로드캐스트 (본인 제외)
+  await Promise.all(
+    connections
+      .filter((c) => c.connectionId !== connectionId)
+      .map((conn) =>
+        sendToConnection(apigw, conn.connectionId, {
+          action: "userJoined",
+          data: { serverId, userId },
+        })
+      )
+  );
 
   return {
     statusCode: 200,
@@ -467,7 +536,7 @@ module.exports.handler = async (event) => {
     const body = JSON.parse(event.body || "{}");
 
     if (routeKey === "createServer")  return await createServer(body);
-    if (routeKey === "joinServer")    return await joinServer(event.requestContext.connectionId, body);
+    if (routeKey === "joinServer")    return await joinServer(event.requestContext.connectionId, body, event);
     if (routeKey === "sendMessage") return await sendMessage(event, body);
     if (routeKey === "updateMessage") return await updateMessage(event, body);
     if (routeKey === "deleteMessage") return await deleteMessage(event, body);

--- a/backend/src/chat/chatHandler.js
+++ b/backend/src/chat/chatHandler.js
@@ -415,7 +415,7 @@ async function resourceUpdated(event, body) {
   const stage = event.requestContext.stage;
   const apigw = getApigwClient(domain, stage);
 
-  const { serverId, resourceType, resource } = body;
+  const { serverId, resourceType, resourceAction, data: resourceData } = body;
 
   if (!serverId) {
     return {
@@ -434,15 +434,16 @@ async function resourceUpdated(event, body) {
 
   const connections = response.Items || [];
 
-  // 브로드캐스트
+  // 프론트가 보낸 형식 그대로 전달 (resourceType, resourceAction, data 포함)
   await Promise.all(
     connections.map((conn) =>
       sendToConnection(apigw, conn.connectionId, {
         action: "resourceUpdated",
         data: {
           serverId,
-          resourceType: resourceType || "unknown",
-          resource: resource || null,
+          resourceType,
+          resourceAction,
+          data: resourceData,
           updatedAt: new Date().toISOString(),
         },
       })

--- a/backend/src/chat/chatHandler.js
+++ b/backend/src/chat/chatHandler.js
@@ -363,11 +363,15 @@ async function deleteMessage(event, body) {
 // AI 분석 시작 알림 브로드캐스트
 // =========================
 async function aiAnalysisStarted(event, body) {
+  console.log("📢 aiAnalysisStarted 진입:", JSON.stringify(body));  // ← 추가
+  
   const domain = event.requestContext.domainName;
   const stage = event.requestContext.stage;
   const apigw = getApigwClient(domain, stage);
 
   const { serverId, fileName, requestId, requestedBy } = body;
+  
+  console.log("📢 추출 결과:", { serverId, requestId });  // ← 추가
 
   if (!serverId || !requestId) {
     return {
@@ -375,8 +379,9 @@ async function aiAnalysisStarted(event, body) {
       body: JSON.stringify({ message: "serverId, requestId가 필요합니다." }),
     };
   }
+  
+  console.log("📢 Connections 조회 시작");  // ← 추가
 
-  // 같은 서버 접속자 전체 조회
   const response = await dynamoDb.send(new QueryCommand({
     TableName: CONNECTIONS_TABLE,
     IndexName: "serverId-index",
@@ -384,27 +389,23 @@ async function aiAnalysisStarted(event, body) {
     ExpressionAttributeValues: { ":serverId": serverId },
   }));
 
+  console.log("📢 Connections 결과:", response.Items?.length, "건");  // ← 추가
+
   const connections = response.Items || [];
 
-  // 브로드캐스트
   await Promise.all(
     connections.map((conn) =>
       sendToConnection(apigw, conn.connectionId, {
         action: "aiAnalysisStarted",
-        data: {
-          serverId,
-          fileName,
-          requestId,
-          requestedBy,
-          startedAt: new Date().toISOString(),
-        },
+        data: { serverId, fileName, requestId, requestedBy, startedAt: new Date().toISOString() },
       })
     )
   );
 
+  console.log("📢 브로드캐스트 완료");  // ← 추가
+
   return { statusCode: 200 };
 }
-
 
 // =========================
 // 리소스 업데이트 브로드캐스트

--- a/backend/src/chat/chatHandler.js
+++ b/backend/src/chat/chatHandler.js
@@ -432,15 +432,11 @@ async function deleteMessage(event, body) {
 // AI 분석 시작 알림 브로드캐스트
 // =========================
 async function aiAnalysisStarted(event, body) {
-  console.log("📢 aiAnalysisStarted 진입:", JSON.stringify(body));  // ← 추가
-  
   const domain = event.requestContext.domainName;
   const stage = event.requestContext.stage;
   const apigw = getApigwClient(domain, stage);
 
   const { serverId, fileName, requestId, requestedBy } = body;
-  
-  console.log("📢 추출 결과:", { serverId, requestId });  // ← 추가
 
   if (!serverId || !requestId) {
     return {
@@ -448,8 +444,6 @@ async function aiAnalysisStarted(event, body) {
       body: JSON.stringify({ message: "serverId, requestId가 필요합니다." }),
     };
   }
-  
-  console.log("📢 Connections 조회 시작");  // ← 추가
 
   const response = await dynamoDb.send(new QueryCommand({
     TableName: CONNECTIONS_TABLE,
@@ -457,8 +451,6 @@ async function aiAnalysisStarted(event, body) {
     KeyConditionExpression: "serverId = :serverId",
     ExpressionAttributeValues: { ":serverId": serverId },
   }));
-
-  console.log("📢 Connections 결과:", response.Items?.length, "건");  // ← 추가
 
   const connections = response.Items || [];
 
@@ -470,8 +462,6 @@ async function aiAnalysisStarted(event, body) {
       })
     )
   );
-
-  console.log("📢 브로드캐스트 완료");  // ← 추가
 
   return { statusCode: 200 };
 }

--- a/backend/src/chat/chatHandler.js
+++ b/backend/src/chat/chatHandler.js
@@ -359,6 +359,52 @@ async function deleteMessage(event, body) {
   };
 }
 
+// =========================
+// AI 분석 시작 알림 브로드캐스트
+// =========================
+async function aiAnalysisStarted(event, body) {
+  const domain = event.requestContext.domainName;
+  const stage = event.requestContext.stage;
+  const apigw = getApigwClient(domain, stage);
+
+  const { serverId, fileName, requestId, requestedBy } = body;
+
+  if (!serverId || !requestId) {
+    return {
+      statusCode: 400,
+      body: JSON.stringify({ message: "serverId, requestId가 필요합니다." }),
+    };
+  }
+
+  // 같은 서버 접속자 전체 조회
+  const response = await dynamoDb.send(new QueryCommand({
+    TableName: CONNECTIONS_TABLE,
+    IndexName: "serverId-index",
+    KeyConditionExpression: "serverId = :serverId",
+    ExpressionAttributeValues: { ":serverId": serverId },
+  }));
+
+  const connections = response.Items || [];
+
+  // 브로드캐스트
+  await Promise.all(
+    connections.map((conn) =>
+      sendToConnection(apigw, conn.connectionId, {
+        action: "aiAnalysisStarted",
+        data: {
+          serverId,
+          fileName,
+          requestId,
+          requestedBy,
+          startedAt: new Date().toISOString(),
+        },
+      })
+    )
+  );
+
+  return { statusCode: 200 };
+}
+
 
 // =========================
 // 리소스 업데이트 브로드캐스트
@@ -424,6 +470,7 @@ module.exports.handler = async (event) => {
     if (routeKey === "updateMessage") return await updateMessage(event, body);
     if (routeKey === "deleteMessage") return await deleteMessage(event, body);
     if (routeKey === "resourceUpdated") return await resourceUpdated(event, body);
+    if (routeKey === "aiAnalysisStarted") return await aiAnalysisStarted(event, body);
 
     return { statusCode: 200 };
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -18,6 +18,7 @@
         "react-hook-form": "^7.72.0",
         "react-router-dom": "^7.13.2",
         "react-scripts": "5.0.1",
+        "uuid": "^14.0.0",
         "web-vitals": "^2.1.4",
         "zod": "^4.3.6"
       }
@@ -14916,6 +14917,16 @@
         "websocket-driver": "^0.7.4"
       }
     },
+    "node_modules/sockjs/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/source-list-map": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
@@ -15681,23 +15692,6 @@
         }
       }
     },
-    "node_modules/tailwindcss/node_modules/yaml": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
-    },
     "node_modules/tapable": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.2.tgz",
@@ -16401,12 +16395,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/v8-to-istanbul": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
     "react-hook-form": "^7.72.0",
     "react-router-dom": "^7.13.2",
     "react-scripts": "5.0.1",
+    "uuid": "^14.0.0",
     "web-vitals": "^2.1.4",
     "zod": "^4.3.6"
   },

--- a/frontend/src/components/Chat/ChatLayout.js
+++ b/frontend/src/components/Chat/ChatLayout.js
@@ -80,7 +80,7 @@ const ChatLayout = () => {
     const { action, data } = parsed;
 
     // 채팅 메시지 관련 → ChatWindow 핸들러로 위임
-    if (['receiveMessage', 'messageUpdated', 'messageDeleted'].includes(action)) {
+    if (['receiveMessage', 'messageUpdated', 'messageDeleted', 'aiAnalysisStarted'].includes(action)) {
       chatMessageHandlerRef.current?.(parsed);
       return;
     }

--- a/frontend/src/components/Chat/ChatLayout.js
+++ b/frontend/src/components/Chat/ChatLayout.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useState, useRef } from "react";
+import React, { useCallback, useEffect, useMemo, useState, useRef } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import { PATHS } from "../../constants/path";
 import { useServers } from "../../contexts/ServerContext";
@@ -37,6 +37,12 @@ const ChatLayout = () => {
 
   const [isServerModalOpen, setIsServerModalOpen] = useState(false);
   const [isChannelModalOpen, setIsChannelModalOpen] = useState(false);
+  const [onlineUserIds, setOnlineUserIds] = useState([]);
+
+  // ✅ 서버 변경 시 onlineUserIds 초기화
+  useEffect(() => {
+    setOnlineUserIds([]);
+  }, [serverId]);
 
   const handleLogout = async () => {
     try {
@@ -82,6 +88,27 @@ const ChatLayout = () => {
     // 채팅 메시지 관련 → ChatWindow 핸들러로 위임
     if (['receiveMessage', 'messageUpdated', 'messageDeleted', 'aiAnalysisStarted'].includes(action)) {
       chatMessageHandlerRef.current?.(parsed);
+      return;
+    }
+
+    // ✅ 온라인 멤버 리스트 (입장 직후 본인이 받음)
+    if (action === 'onlineMembers' && data) {
+      setOnlineUserIds(data.onlineUserIds || []);
+      return;
+    }
+
+    // ✅ 다른 사람 입장 알림
+    if (action === 'userJoined' && data?.userId) {
+      setOnlineUserIds((prev) => {
+        if (prev.includes(data.userId)) return prev;
+        return [...prev, data.userId];
+      });
+      return;
+    }
+
+    // ✅ 다른 사람 퇴장 알림
+    if (action === 'userLeft' && data?.userId) {
+      setOnlineUserIds((prev) => prev.filter((id) => id !== data.userId));
       return;
     }
 
@@ -218,6 +245,7 @@ const ChatLayout = () => {
         contextMenuTargetId={contextMenu?.targetId}
         members={currentServer?.members || []}
         hostId={currentServer?.hostId}
+        onlineUserIds={onlineUserIds}
         onServerContextMenu={(event) =>
           openContextMenu(event, { type: "server", targetId: serverId, title: getServerName(currentServer), items: serverMenuItems })
         }

--- a/frontend/src/components/Chat/ChatWindow.js
+++ b/frontend/src/components/Chat/ChatWindow.js
@@ -7,6 +7,8 @@ const IMAGE_MESSAGE_TYPES = new Set(["IMAGE", "image"]);
 const FILE_MESSAGE_TYPES = new Set(["FILE", "file"]);
 const LINK_MESSAGE_TYPES = new Set(["LINK", "link"]);
 const AI_SUMMARY_MESSAGE_TYPES = new Set(["ai-summary", "AI_SUMMARY"]);
+const AI_PENDING_MESSAGE_TYPES = new Set(["ai-pending"]);
+const AI_FAILED_MESSAGE_TYPES = new Set(["ai-failed"]);
 
 // Helper for deduplication
 const isSameMessage = (left, right) => {
@@ -103,6 +105,7 @@ const ChatWindow = ({ activeChannel, channels, sendWsMessage, isConnected, chatM
   const dragDepthRef = useRef(0);
   const messagesEndRef = useRef(null);
   const fileInputRef = useRef(null);
+  const aiPendingTimeoutsRef = useRef(new Map()); // requestId → timeoutId
 
   const activeChannelRef = useRef(activeChannel);
   useEffect(() => {
@@ -194,6 +197,30 @@ const ChatWindow = ({ activeChannel, channels, sendWsMessage, isConnected, chatM
     const channelId = data?.channelId || activeChannelRef.current;
 
     if (action === "receiveMessage" && data) {
+      // ai-summary 도착 시: 같은 requestId의 ai-pending 제거 + 타이머 정리
+      if (
+        (AI_SUMMARY_MESSAGE_TYPES.has(data.messageType) || AI_SUMMARY_MESSAGE_TYPES.has(data.type)) &&
+        data.aiRequestId
+      ) {
+        const timeoutId = aiPendingTimeoutsRef.current.get(data.aiRequestId);
+        if (timeoutId) {
+          clearTimeout(timeoutId);
+          aiPendingTimeoutsRef.current.delete(data.aiRequestId);
+        }
+        // ai-pending 제거 후 ai-summary 추가
+        setChannelMessages((prev) => {
+          const targetChannel = channelId;
+          const filtered = (prev[targetChannel] || []).filter(
+            (m) => !(m.aiRequestId === data.aiRequestId && AI_PENDING_MESSAGE_TYPES.has(m.messageType)),
+          );
+          return {
+            ...prev,
+            [targetChannel]: [...filtered, data],
+          };
+        });
+        return;
+      }
+
       appendMessageToChannel(channelId, data);
       return;
     }
@@ -215,6 +242,55 @@ const ChatWindow = ({ activeChannel, channels, sendWsMessage, isConnected, chatM
           msg.messageId === data.messageId ? { ...msg, ...data } : msg,
         ),
       }));
+      return;
+    }
+
+    // AI 분석 시작 알림 → 임시 메시지 추가 + 5분 타이머 등록
+    if (action === "aiAnalysisStarted" && data) {
+      const { requestId, fileName, requestedBy, startedAt } = data;
+      if (!requestId) return;
+
+      const targetChannel = channelId;
+
+      setChannelMessages((prev) => {
+        const existing = prev[targetChannel] || [];
+        // 중복 방지
+        if (existing.some((m) => m.aiRequestId === requestId && AI_PENDING_MESSAGE_TYPES.has(m.messageType))) {
+          return prev;
+        }
+        return {
+          ...prev,
+          [targetChannel]: [
+            ...existing,
+            {
+              messageId: `ai-pending-${requestId}`,
+              messageType: "ai-pending",
+              aiRequestId: requestId,
+              channelId: targetChannel,
+              fileName,
+              requestedBy,
+              createdAt: startedAt || new Date().toISOString(),
+              senderId: "system-ai",
+              senderNickname: "AI 스터디 조교",
+            },
+          ],
+        };
+      });
+
+      // 5분 후 자동 실패 처리
+      const timeoutId = setTimeout(() => {
+        setChannelMessages((prev) => ({
+          ...prev,
+          [targetChannel]: (prev[targetChannel] || []).map((m) =>
+            m.aiRequestId === requestId && AI_PENDING_MESSAGE_TYPES.has(m.messageType)
+              ? { ...m, messageType: "ai-failed", messageId: `ai-failed-${requestId}` }
+              : m,
+          ),
+        }));
+        aiPendingTimeoutsRef.current.delete(requestId);
+      }, 5 * 60 * 1000);
+
+      aiPendingTimeoutsRef.current.set(requestId, timeoutId);
     }
   }, [appendMessageToChannel]);
 
@@ -240,6 +316,13 @@ const ChatWindow = ({ activeChannel, channels, sendWsMessage, isConnected, chatM
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: "auto" });
   }, [activeChannel]);
+
+  useEffect(() => {
+    return () => {
+      aiPendingTimeoutsRef.current.forEach((timeoutId) => clearTimeout(timeoutId));
+      aiPendingTimeoutsRef.current.clear();
+    };
+  }, []);
 
   const broadcastUploadedFile = useCallback((savedFile, content = "") => {
     if (!savedFile || !activeChannel || !isConnected) return;
@@ -483,6 +566,9 @@ const ChatWindow = ({ activeChannel, channels, sendWsMessage, isConnected, chatM
     if (AI_SUMMARY_MESSAGE_TYPES.has(msg.type) || AI_SUMMARY_MESSAGE_TYPES.has(msg.messageType)) {
       return true;
     }
+    if (AI_PENDING_MESSAGE_TYPES.has(messageType) || AI_FAILED_MESSAGE_TYPES.has(messageType)) {
+      return true;
+    }
     if (IMAGE_MESSAGE_TYPES.has(messageType)) {
       return Boolean(msg.imageUrl || content);
     }
@@ -548,6 +634,76 @@ const ChatWindow = ({ activeChannel, channels, sendWsMessage, isConnected, chatM
                   <div className="avatar" style={{ opacity: 0.4 }}>?</div>
                   <div className="message-content">
                     <p style={{ color: "#52525b", fontStyle: "italic" }}>삭제된 메시지입니다.</p>
+                  </div>
+                </div>
+              );
+            }
+
+            // AI 분석 진행 중 임시 메시지
+            if (AI_PENDING_MESSAGE_TYPES.has(msg.messageType)) {
+              return (
+                <div key={key} className="ai-summary-box" style={{ opacity: 0.7 }}>
+                  <div className="ai-summary-header">
+                    <span className="ai-icon">🔄</span>
+                    <span className="ai-label">SAGE AI</span>
+                    <span className="ai-tag">분석 중</span>
+                    {msg.fileName && (
+                      <span
+                        className="ai-filename"
+                        style={{
+                          marginLeft: "8px",
+                          fontSize: "12px",
+                          color: "#a1a1aa",
+                          fontStyle: "italic",
+                        }}
+                      >
+                        📎 {msg.fileName}
+                      </span>
+                    )}
+                  </div>
+                  <div className="ai-summary-content">
+                    <div style={{ fontSize: "13px", color: "#d4d4d8", lineHeight: 1.6 }}>
+                      {msg.requestedBy ? `${msg.requestedBy}님이 요청한` : "요청된"} 파일을 분석하고 있어요.
+                      <br />
+                      <span style={{ fontSize: "11px", color: "#71717a" }}>
+                        PDF는 1~5분 소요됩니다. 완료되면 자동으로 결과가 표시됩니다.
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              );
+            }
+
+            // AI 분석 실패 메시지
+            if (AI_FAILED_MESSAGE_TYPES.has(msg.messageType)) {
+              return (
+                <div key={key} className="ai-summary-box" style={{ opacity: 0.6 }}>
+                  <div className="ai-summary-header">
+                    <span className="ai-icon">❌</span>
+                    <span className="ai-label" style={{ color: "#ef4444" }}>SAGE AI</span>
+                    <span className="ai-tag" style={{ color: "#ef4444" }}>분석 실패</span>
+                    {msg.fileName && (
+                      <span
+                        className="ai-filename"
+                        style={{
+                          marginLeft: "8px",
+                          fontSize: "12px",
+                          color: "#a1a1aa",
+                          fontStyle: "italic",
+                        }}
+                      >
+                        📎 {msg.fileName}
+                      </span>
+                    )}
+                  </div>
+                  <div className="ai-summary-content">
+                    <div style={{ fontSize: "13px", color: "#d4d4d8", lineHeight: 1.6 }}>
+                      분석에 시간이 너무 오래 걸려 중단되었습니다.
+                      <br />
+                      <span style={{ fontSize: "11px", color: "#71717a" }}>
+                        잠시 후 🤖 버튼으로 다시 시도해주세요.
+                      </span>
+                    </div>
                   </div>
                 </div>
               );

--- a/frontend/src/components/Chat/ChatWindow.js
+++ b/frontend/src/components/Chat/ChatWindow.js
@@ -318,9 +318,10 @@ const ChatWindow = ({ activeChannel, channels, sendWsMessage, isConnected, chatM
   }, [activeChannel]);
 
   useEffect(() => {
+    const timeoutsMap = aiPendingTimeoutsRef.current;
     return () => {
-      aiPendingTimeoutsRef.current.forEach((timeoutId) => clearTimeout(timeoutId));
-      aiPendingTimeoutsRef.current.clear();
+      timeoutsMap.forEach((timeoutId) => clearTimeout(timeoutId));
+      timeoutsMap.clear();
     };
   }, []);
 

--- a/frontend/src/components/Chat/ResourceHub.js
+++ b/frontend/src/components/Chat/ResourceHub.js
@@ -1,7 +1,9 @@
 import React, { useState, useRef } from 'react';
 import { useParams } from 'react-router-dom';
+import { v4 as uuidv4 } from 'uuid';
 import { uploadFile, saveLink, deleteFile, deleteLink } from '../../lib/resources';
 import { request } from '../../lib/request';
+import { useAuth } from '../../contexts/AuthContext';
 
 import './ResourceHub.css';
 
@@ -29,6 +31,7 @@ const isAnalyzable = (fileName, fileType) => {
  * @param {function} sendWsMessage - WebSocket 메시지 전송 함수 (ChatLayout에서 전달)
  */
 const ResourceHub = ({ serverResources, setCurrentServer, sendWsMessage }) => {
+  const { user } = useAuth();
   const [activeHubTab, setActiveHubTab] = useState('Files');
   const { serverId } = useParams();
   const fileInputRef = useRef(null);
@@ -113,7 +116,20 @@ const ResourceHub = ({ serverResources, setCurrentServer, sendWsMessage }) => {
       else if (ext === 'webp') fileType = 'image/webp';
     }
 
+    // 임시 메시지 식별용 uuid
+    const requestId = uuidv4();
+
     setAnalyzingFileId(file.fileId);
+
+    // 1. 같은 채널 모든 사람에게 "분석 시작" 브로드캐스트
+    sendWsMessage?.('aiAnalysisStarted', {
+      serverId,
+      fileName: file.fileName,
+      requestId,
+      requestedBy: user?.nickname || '누군가',
+    });
+
+    // 2. AI 분석 요청 (백엔드)
     try {
       await request('/ai/analyze', {
         method: 'POST',
@@ -122,12 +138,13 @@ const ResourceHub = ({ serverResources, setCurrentServer, sendWsMessage }) => {
           s3ObjectKey: file.s3ObjectKey,
           fileType,
           fileName: file.fileName,
+          requestId, // 같은 requestId 함께 전송 → 결과에 aiRequestId로 박혀 돌아옴
         }),
       });
-      alert('AI 분석이 완료되었습니다. 채팅창에서 결과를 확인하세요.');
+      // 정상 완료. 임시 메시지는 ai-summary 도착 시 자동 교체됨.
     } catch (error) {
-      console.error('AI 분석 요청:', error);
-      alert('AI 분석을 요청했습니다. PDF는 분석에 1~2분 소요됩니다. 완료되면 채팅창에 자동으로 결과가 표시됩니다.');
+      // API Gateway 29초 타임아웃은 정상 (Lambda는 백그라운드 실행 중)
+      console.log('AI 분석 요청 진행 중:', error.message);
     } finally {
       setAnalyzingFileId(null);
     }


### PR DESCRIPTION
## 📌 관련 이슈
없음 (UI/UX 명세서 SCR-009 미구현 항목 보강 + 실시간 동기화 개선)

## 🏷️ 작업 유형 (Type of Change)
- [x] ✨ 기능 추가 (Feature)
- [x] 🐛 버그 수정 (Fix)
- [ ] 🎨 UI/UX 및 디자인 변경 (Design)
- [ ] ♻️ 리팩토링 (Refactor)
- [ ] 📝 문서 작업 (Docs)

## 🚀 작업 내용

### 1. AI 분석 진행 상태 표시 UI (Feature)
**배경**
🤖 버튼 클릭 후 분석 결과(SAGE AI 메시지)가 도착할 때까지 사용자에게 아무 피드백이 없어, 분석이 진행 중인지 실패한 건지 알 수 없는 문제.
UI/UX 명세서 SCR-009의 "분석 진행 스텝퍼", "분석 실패 메시지" 요구사항이 미구현이었음.

**구현**
- 🤖 클릭 시 프론트가 `uuid`로 `requestId` 생성 → REST `/ai/analyze`와 WebSocket `aiAnalysisStarted` 동시 발사
- 백엔드 `chatHandler`가 같은 채널 모든 사용자에게 브로드캐스트
- 프론트가 임시 메시지(`ai-pending`)를 채팅창에 즉시 표시 ("🔄 SAGE AI 분석 중")
- 분석 완료 시 `ai-summary` 결과가 `aiRequestId` 매칭으로 임시 메시지를 자동 교체
- 5분 타임아웃 시 임시 메시지가 `ai-failed`로 자동 교체 ("❌ AI 분석 실패")

**변경 파일**
- `backend/src/ai/aiRouter.js`: 요청 시 `requestId` 받아 결과 메시지에 `aiRequestId` 포함
- `backend/src/chat/chatHandler.js`: 새 함수 `aiAnalysisStarted` + 라우터 분기 추가
- `frontend/src/components/Chat/ChatLayout.js`: WebSocket 액션 위임 추가
- `frontend/src/components/Chat/ResourceHub.js`: uuid 생성 + sendWsMessage 호출
- `frontend/src/components/Chat/ChatWindow.js`: `ai-pending`/`ai-failed` 타입 추가, 매칭 로직, 5분 타이머, 렌더링 분기

### 2. 파일/링크 업로드 실시간 동기화 버그 수정 (Fix)
**문제**
한 사용자가 파일/링크를 업로드해도 같은 서버의 다른 사용자에게는 새로고침 전까지 보이지 않음.

**원인**
`chatHandler.js`의 `resourceUpdated` 함수가 프론트 페이로드와 다른 형식으로 데이터를 전달:
- 프론트: `{ resourceType, resourceAction, data }` 전송
- 백엔드: `{ resourceType, resource }`만 받아 `resource: null`로 전달

**해결**
백엔드가 프론트 페이로드를 그대로 다른 사용자에게 전달하도록 수정.

### 3. 온라인 멤버 실시간 동기화 (Feature)
**문제**
사이드바의 온라인/오프라인 멤버 표시가 실시간 갱신되지 않음. 본인만 항상 온라인으로 표시되고 다른 사람의 입장/퇴장이 반영되지 않음.

**구현**
- 백엔드 `joinServer`: 입장한 사용자에게 현재 온라인 멤버 리스트 전송 + 다른 사용자에게 `userJoined` 브로드캐스트
- 백엔드 `onDisconnect`: 끊긴 connection의 serverId/userId 조회 후 같은 서버 다른 사용자에게 `userLeft` 브로드캐스트
- 프론트 `ChatLayout`: `onlineMembers`/`userJoined`/`userLeft` 액션 처리하여 `onlineUserIds` state 관리
- 프론트 `SidebarLeft`: `onlineUserIds` prop 받아 멤버 목록을 온라인/오프라인으로 분류

## ✅ 체크리스트
- [x] `README.md`에 명시된 코딩 컨벤션 및 커밋 메시지 규칙을 준수했습니다.
- [x] 관련 없는 코드나 불필요한 주석을 포함하지 않았습니다.
- [x] 작업할 브랜치(`dev`)의 최신 상태를 pull 받아 충돌이 없는 것을 확인했습니다.
- [x] (Backend) 람다 함수나 DB 스키마 변경 시 로컬/테스트 환경에서 검증을 완료했습니다.
  - CloudShell에서 `./deploy.sh`로 배포 후 통합 테스트 완료
  - 검증 시나리오: 두 브라우저(시크릿창 포함)로 같은 서버 접속하여 파일 업로드/삭제, 링크 추가/삭제, AI 분석 실행, 입장/퇴장 모두 실시간 동기화 확인

## 💬 리뷰어에게

**인프라 변경사항**
- AWS WebSocket API에 `aiAnalysisStarted` 라우트 신규 등록 + Lambda invoke 권한 부여 완료
- WebSocket API 재배포(stage: dev) 완료
- 신규 라우트 추가 시 다음 3가지가 모두 필요함 (인수인계용 메모):
  1. `aws apigatewayv2 create-route` (라우트 생성)
  2. `aws apigatewayv2 create-deployment` (Stage 반영)
  3. `aws lambda add-permission` (라우트 단위 invoke 권한)
- 셋 중 하나 누락 시 API Gateway가 Lambda 호출 못 하고 `Internal server error` 반환

**REST API 29초 타임아웃 한계**
- AI 분석은 평균 1~5분 소요되므로 REST API 응답을 기다리지 않고 WebSocket으로 결과 통보
- `ResourceHub.js`의 catch 블록에서 504 에러를 무시하는 패턴 적용 (의도된 흐름)

**5분 타임아웃 결정**
- AWS Textract 처리 시간이 18초~4분+ 까지 변동 큼 (us-east-1 부하 시간대 영향)
- 5분 후에도 결과가 안 오면 사용자에게 명확한 실패 메시지 표시