### PR TITLE
Feat: 로딩 시 Skeleton UI 및 Empty State 구현

### DIFF
--- a/frontend/src/components/Chat/ChatLayout.css
+++ b/frontend/src/components/Chat/ChatLayout.css
@@ -925,3 +925,61 @@
   padding: 12px 8px;
   text-align: center;
 }
+
+/* ── 채널 목록 Skeleton UI ── */
+.channel-skeleton-list {
+  padding: 8px 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+ 
+.channel-skeleton-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px;
+  border-radius: 6px;
+}
+ 
+.skeleton-hash {
+  width: 14px;
+  height: 14px;
+  flex-shrink: 0;
+  border-radius: 3px;
+}
+ 
+.skeleton-channel-name {
+  height: 13px;
+  flex: 1;
+}
+ 
+/* ── 채널 Empty State ── */
+.channel-empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 24px 16px;
+  text-align: center;
+  gap: 4px;
+}
+ 
+.channel-empty-icon {
+  font-size: 24px;
+  color: #3f3f46;
+  font-weight: 700;
+}
+ 
+.channel-empty-text {
+  margin: 0;
+  font-size: 13px;
+  font-weight: 600;
+  color: #52525b;
+}
+ 
+.channel-empty-sub {
+  margin: 0;
+  font-size: 11px;
+  color: #3f3f46;
+  line-height: 1.5;
+}

--- a/frontend/src/components/Chat/ChatLayout.js
+++ b/frontend/src/components/Chat/ChatLayout.js
@@ -208,9 +208,9 @@ const ChatLayout = () => {
   const handleChannelSettingsSubmit = async (values) => { await saveChannelSettings(settingsModal?.channel, values); closeSettingsModal(); };
   const handleCreateChannel = async (values) => { await createChannelInServer(values); setIsChannelModalOpen(false); };
 
-  if (loading) return <div style={{ color: "white", padding: "20px" }}>서버 정보를 가져오는 중...</div>;
+  // if (loading) return <div style={{ color: "white", padding: "20px" }}>서버 정보를 가져오는 중...</div>;
 
-  if (!currentServer) {
+  if (!loading && !currentServer) {
     return (
       <div style={{ padding: "20px", color: "white" }}>
         <h3>서버를 찾을 수 없습니다. (ID: {serverId})</h3>
@@ -235,6 +235,7 @@ const ChatLayout = () => {
         }}
       />
 
+      {/* ✅ loading prop 전달 → 로딩 중엔 Skeleton 표시 */}
       <SidebarLeft
         serverName={getServerName(currentServer, "로딩 중...")}
         channels={currentServer?.channels || []}
@@ -246,6 +247,7 @@ const ChatLayout = () => {
         members={currentServer?.members || []}
         hostId={currentServer?.hostId}
         onlineUserIds={onlineUserIds}
+        loading={loading}
         onServerContextMenu={(event) =>
           openContextMenu(event, { type: "server", targetId: serverId, title: getServerName(currentServer), items: serverMenuItems })
         }
@@ -268,19 +270,41 @@ const ChatLayout = () => {
       />
 
       <main className="chat-content-wrapper" style={{ display: "flex", flex: 1, minWidth: 0 }}>
-        {/* ✅ ChatWindow에 sendWsMessage, isConnected, chatMessageHandlerRef 전달 */}
-        <ChatWindow
-          activeChannel={activeChannel}
-          channels={currentServer.channels}
-          sendWsMessage={sendWsMessage}
-          isConnected={isConnected}
-          chatMessageHandlerRef={chatMessageHandlerRef}
-        />
+        {loading ? (
+          // ✅ 로딩 중 채팅창 Skeleton
+          <div className="chat-main">
+            <div className="chat-header">
+              <div className="skeleton" style={{ width: 120, height: 16, borderRadius: 6 }} />
+            </div>
+            <div className="chat-messages" style={{ gap: 16 }}>
+              {[...Array(5)].map((_, i) => (
+                <div key={i} className="message-dummy">
+                  <div className="skeleton" style={{ width: 40, height: 40, borderRadius: '50%', flexShrink: 0 }} />
+                  <div style={{ display: 'flex', flexDirection: 'column', gap: 8, flex: 1 }}>
+                    <div className="skeleton" style={{ width: 80, height: 12, borderRadius: 4 }} />
+                    <div className="skeleton" style={{ width: `${50 + i * 8}%`, height: 14, borderRadius: 4 }} />
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        ) : (
+          //✅ ChatWindow에 sendWsMessage, isConnected, chatMessageHandlerRef 전달
+          <ChatWindow 
+            activeChannel={activeChannel}
+            channels={currentServer.channels}
+            sendWsMessage={sendWsMessage}
+            isConnected={isConnected}
+            chatMessageHandlerRef={chatMessageHandlerRef}
+          />
+        )}
+
         {/* ✅ ResourceHub에 sendWsMessage 전달 */}
         <ResourceHub
           serverResources={currentServer}
           setCurrentServer={setCurrentServer}
           sendWsMessage={sendWsMessage}
+          loading={loading}
         />
       </main>
 

--- a/frontend/src/components/Chat/ResourceHub.css
+++ b/frontend/src/components/Chat/ResourceHub.css
@@ -59,3 +59,64 @@
   opacity: 0.5;
   cursor: not-allowed;
 }
+
+/* ── Skeleton UI ── */
+.hub-skeleton-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+ 
+.hub-skeleton-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px;
+  border-radius: 6px;
+}
+ 
+.hub-skeleton-icon {
+  width: 34px;
+  height: 34px;
+  border-radius: 6px;
+  flex-shrink: 0;
+}
+ 
+.hub-skeleton-info {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  flex: 1;
+}
+ 
+.hub-skeleton-name {
+  height: 12px;
+  border-radius: 4px;
+}
+ 
+.hub-skeleton-meta {
+  height: 10px;
+  border-radius: 4px;
+}
+ 
+/* ── Empty State ── */
+.hub-empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 32px 16px;
+  text-align: center;
+  gap: 8px;
+}
+ 
+.hub-empty-icon {
+  font-size: 32px;
+  opacity: 0.4;
+}
+ 
+.hub-empty-text {
+  margin: 0;
+  font-size: 12px;
+  color: #52525b;
+}

--- a/frontend/src/components/Chat/ResourceHub.js
+++ b/frontend/src/components/Chat/ResourceHub.js
@@ -25,12 +25,36 @@ const isAnalyzable = (fileName, fileType) => {
   return false;
 };
 
+// ✅ 파일/링크 목록 Skeleton UI
+const ResourceSkeleton = () => (
+  <div className="hub-skeleton-list">
+    {[...Array(4)].map((_, i) => (
+      <div key={i} className="hub-skeleton-item">
+        <div className="skeleton hub-skeleton-icon" />
+        <div className="hub-skeleton-info">
+          <div className="skeleton hub-skeleton-name" style={{ width: `${50 + i * 10}%` }} />
+          <div className="skeleton hub-skeleton-meta" style={{ width: `${30 + i * 8}%` }} />
+        </div>
+      </div>
+    ))}
+  </div>
+);
+
+// ✅ Empty State
+const EmptyState = ({ icon, text }) => (
+  <div className="hub-empty-state">
+    <span className="hub-empty-icon">{icon}</span>
+    <p className="hub-empty-text">{text}</p>
+  </div>
+);
+
 /**
  * @param {object} serverResources - 서버 상세 데이터
  * @param {function} setCurrentServer - 서버 state 업데이트 함수
  * @param {function} sendWsMessage - WebSocket 메시지 전송 함수 (ChatLayout에서 전달)
+ * @param {boolean} loading - 서버 데이터 로딩 상태
  */
-const ResourceHub = ({ serverResources, setCurrentServer, sendWsMessage }) => {
+const ResourceHub = ({ serverResources, setCurrentServer, sendWsMessage, loading = false }) => {
   const { user } = useAuth();
   const [activeHubTab, setActiveHubTab] = useState('Files');
   const { serverId } = useParams();
@@ -264,7 +288,13 @@ const ResourceHub = ({ serverResources, setCurrentServer, sendWsMessage }) => {
               <input ref={fileInputRef} type="file" style={{ display: 'none' }} onChange={handleFileSelect} />
             </div>
             <div className="hub-file-list">
-              {files.length > 0 ? files.map(renderFileItem) : <div className="empty-msg">공유된 파일이 없습니다.</div>}
+              {/* ✅ 로딩 중 → Skeleton / 파일 없음 → Empty State / 있음 → 목록 */}
+              {loading ? (
+                <ResourceSkeleton />
+              ) : files.length > 0 ? (files.map(renderFileItem)
+              ) : (
+                <EmptyState icon="📁" text="공유된 파일이 없습니다" />
+              )}
             </div>
           </div>
         )}
@@ -273,15 +303,23 @@ const ResourceHub = ({ serverResources, setCurrentServer, sendWsMessage }) => {
           <div className="hub-section">
             <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '10px' }}>
               <p className="hub-section-label">공유된 링크</p>
-              <button
-                onClick={handleLinkAdd}
-                style={{ background: '#00ff66', color: '#000', border: 'none', borderRadius: '4px', padding: '4px 10px', fontSize: '11px', fontWeight: 700, cursor: 'pointer' }}
+              {!loading && (
+                <button
+                  onClick={handleLinkAdd}
+                  style={{ background: '#00ff66', color: '#000', border: 'none', borderRadius: '4px', padding: '4px 10px', fontSize: '11px', fontWeight: 700, cursor: 'pointer' }}
               >
                 + 링크 추가
-              </button>
+                </button>
+              )}
             </div>
             <div className="hub-file-list">
-              {links.length > 0 ? links.map(renderLinkItem) : <div className="empty-msg">공유된 링크가 없습니다.</div>}
+              {loading ? (
+                <ResourceSkeleton />
+              ) : links.length > 0 ? (
+                links.map(renderLinkItem)
+              ) : (
+                <EmptyState icon="🔗" text="공유된 링크가 없습니다" />
+              )}
             </div>
           </div>
         )}

--- a/frontend/src/components/Chat/SidebarLeft.js
+++ b/frontend/src/components/Chat/SidebarLeft.js
@@ -18,6 +18,19 @@ function handleRightClick(event, callback, payload) {
  * @param {Array} members - 서버 멤버 목록 ({userId, nickname, role} 형태)
  * @param {string} hostId - 서버 방장 userId (방장 태그 표시용)
  */
+
+// ✅ 채널 목록 Skeleton UI
+const ChannelSkeleton = () => (
+  <div className="channel-skeleton-list">
+    {[...Array(4)].map((_, i) => (
+      <div key={i} className="channel-skeleton-item">
+        <div className="skeleton skeleton-hash" />
+        <div className="skeleton skeleton-channel-name" style={{ width: `${60 + i * 10}%` }} />
+      </div>
+    ))}
+  </div>
+);
+
 const SidebarLeft = ({
   serverName,
   channels,
@@ -31,6 +44,7 @@ const SidebarLeft = ({
   members = [],
   hostId,
   onlineUserIds = [], // ✅ 웹소켓 연결 시 실시간 온라인 유저 ID 목록
+  loading = false, // ✅ 로딩 상태 prop 추가
 }) => {
   const { user } = useAuth();
 
@@ -67,8 +81,9 @@ const SidebarLeft = ({
       </h2>
 
       <div className="channel-list">
-        {channels && channels.length > 0 ? (
-          channels.map((ch) => {
+        {/* ✅ 로딩 중이면 Skeleton, 채널 있으면 목록, 없으면 Empty State */}
+        {loading ? ( <ChannelSkeleton />) : channels && channels.length > 0 ? 
+        (channels.map((ch) => {
             const cid = ch.chId || ch.id;
             const isActive = activeChannel === cid;
             const isContextOpen = contextMenuType === "channel" && contextMenuTargetId === cid;
@@ -89,9 +104,15 @@ const SidebarLeft = ({
             );
           })
         ) : (
-          <div style={{ padding: "0 20px", fontSize: "0.8rem", color: "#888" }}>
-            채널을 불러오는 중...
+          // ✅ 채널 Empty State
+          <div className="channel-empty-state">
+            <span className="channel-empty-icon">#</span>
+            <p className="channel-empty-text">채널이 없습니다</p>
+            <p className="channel-empty-sub">+ 버튼으로 채널을 추가해보세요</p>
           </div>
+          // <div style={{ padding: "0 20px", fontSize: "0.8rem", color: "#888" }}>
+          //   채널을 불러오는 중...
+          // </div>
         )}
       </div>
 

--- a/frontend/src/components/Servers/ExploreServers.css
+++ b/frontend/src/components/Servers/ExploreServers.css
@@ -369,3 +369,77 @@
   color: #52525b;
   letter-spacing: 0.5px;
 }
+
+/* ── Skeleton UI ── */
+@keyframes shimmer {
+  0%   { background-position: -400px 0; }
+  100% { background-position: 400px 0; }
+}
+ 
+.skeleton {
+  background: linear-gradient(90deg, #27272a 25%, #3f3f46 50%, #27272a 75%);
+  background-size: 800px 100%;
+  animation: shimmer 1.5s infinite;
+  border-radius: 6px;
+}
+ 
+.skeleton-card {
+  pointer-events: none;
+}
+ 
+.skeleton-cover {
+  width: 100%;
+  height: 120px;
+  border-radius: 0;
+}
+ 
+.skeleton-title {
+  height: 16px;
+  width: 70%;
+  margin-bottom: 4px;
+}
+ 
+.skeleton-desc {
+  height: 12px;
+  width: 90%;
+}
+ 
+.skeleton-desc.short {
+  width: 60%;
+}
+ 
+/* ── Empty State ── */
+.empty-state {
+  grid-column: 1 / -1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 60px 20px;
+  text-align: center;
+}
+ 
+.empty-state-icon {
+  font-size: 48px;
+  margin-bottom: 16px;
+  opacity: 0.5;
+}
+ 
+.empty-state-title {
+  font-size: 18px;
+  font-weight: 700;
+  color: #a1a1aa;
+  margin: 0 0 8px;
+}
+ 
+.empty-state-sub {
+  font-size: 14px;
+  color: #52525b;
+  margin: 0;
+  line-height: 1.6;
+}
+ 
+.empty-state-keyword {
+  color: #00ff66;
+  font-weight: 600;
+}

--- a/frontend/src/components/Servers/ExploreServers.js
+++ b/frontend/src/components/Servers/ExploreServers.js
@@ -25,6 +25,30 @@ import {
   normalizeServers,
 } from "../../lib/serverEntity";
 
+// ✅ 서버 카드 Skeleton UI
+const ServerCardSkeleton = () => (
+  <div className="servers-card skeleton-card">
+    <div className="skeleton skeleton-cover" />
+    <div className="servers-body">
+      <div className="skeleton skeleton-title" />
+      <div className="skeleton skeleton-desc" />
+      <div className="skeleton skeleton-desc short" />
+    </div>
+  </div>
+);
+
+// ✅ 검색 결과 없음 Empty State
+const EmptySearchState = ({ query }) => (
+  <div className="empty-state">
+    <div className="empty-state-icon">🔍</div>
+    <p className="empty-state-title">검색 결과가 없어요</p>
+    <p className="empty-state-sub">
+      <span className="empty-state-keyword">"{query}"</span>에 해당하는 서버를 찾을 수 없습니다.
+      <br />다른 검색어를 시도하거나 새 서버를 만들어보세요!
+    </p>
+  </div>
+);
+
 const ServerCard = ({ server, onJoin }) => {
   const name = getServerName(server, "제목 없음");
   const description = server.description;
@@ -46,7 +70,6 @@ const ServerCard = ({ server, onJoin }) => {
         ) : (
           <div className="servers-cover-emoji">{emoji}</div>
         )}
-
         <span className={`servers-badge badge-${displayStatus.toLowerCase()}`}>
           {displayStatus}
         </span>
@@ -74,18 +97,11 @@ const ServerCard = ({ server, onJoin }) => {
           </div>
 
           {isLocked ? (
-            <button className="servers-btn btn-locked" disabled>
-              LOCKED
-            </button>
+            <button className="servers-btn btn-locked" disabled>LOCKED</button>
           ) : isFull ? (
-            <button className="servers-btn btn-locked" disabled>
-              FULL
-            </button>
+            <button className="servers-btn btn-locked" disabled>FULL</button>
           ) : (
-            <button
-              className="servers-btn btn-join"
-              onClick={() => onJoin(server)}
-            >
+            <button className="servers-btn btn-join" onClick={() => onJoin(server)}>
               JOIN
             </button>
           )}
@@ -98,9 +114,9 @@ const ServerCard = ({ server, onJoin }) => {
 const ExploreServers = () => {
   const navigate = useNavigate();
   const { logout, refreshToken, user } = useAuth();
-  const { clearJoinedServers, setActiveServerId, upsertJoinedServer, removeJoinedServer } =
-    useServers();
+  const { clearJoinedServers, setActiveServerId, upsertJoinedServer, removeJoinedServer } = useServers();
   const [servers, setServers] = useState([]);
+  const [loading, setLoading] = useState(true); // ✅ 로딩 상태 추가
   const [searchQuery, setSearchQuery] = useState("");
   const [inviteCode, setInviteCode] = useState("");
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -135,12 +151,14 @@ const ExploreServers = () => {
 
   useEffect(() => {
     setActiveServerId(null);
+    setLoading(true); // ✅ 로딩 시작
     getServers()
       .then((data) => setServers(normalizeServers(data.items || [])))
       .catch((err) => {
         console.error("데이터 로드 실패!", err);
         setServers([]);
-      });
+      })
+      .finally(() => setLoading(false)); // ✅ 로딩 완료
   }, [setActiveServerId]);
 
   const filteredServers = servers.filter((server) => {
@@ -301,22 +319,30 @@ const ExploreServers = () => {
         </div>
 
         <div className="servers-grid">
-            {filteredServers.map((server) => (
+          {/* ✅ 로딩 중 → Skeleton 카드 표시 */}
+          {loading ? (
+            [...Array(4)].map((_, i) => <ServerCardSkeleton key={i} />)
+          ) : filteredServers.length === 0 && searchQuery ? (
+            // ✅ 검색 결과 없음 → Empty State
+            <EmptySearchState query={searchQuery} />
+          ) : ( 
+            filteredServers.map((server) => (
               <ServerCard
                 key={getServerId(server)}
                 server={server}
                 onJoin={handleJoinClick}
               />
-          ))}
+            ))
+          )}
 
-          <div
-            className="servers-card create-card"
-            onClick={() => setIsModalOpen(true)}
-          >
+          {/* 방 만들기 카드 - 로딩 중이 아닐 때만 표시 */}
+          {!loading && (
+          <div className="servers-card create-card" onClick={() => setIsModalOpen(true)}>
             <div className="create-plus">+</div>
             <p className="create-label">서버 만들기</p>
             <p className="create-sub">새로운 학습 세션 시작하기</p>
           </div>
+          )}
         </div>
       </div>
 


### PR DESCRIPTION
## 📌 관련 이슈
#(이슈 번호)

## 🏷️ 작업 유형 (Type of Change)
- [x] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Fix)
- [x] 🎨 UI/UX 및 디자인 변경 (Design)
- [ ] ♻️ 리팩토링 (Refactor)
- [ ] 📝 문서 작업 (Docs)

## 🚀 작업 내용
- `SidebarLeft.js`: 채널 목록 로딩 시 Skeleton UI 적용, 채널 없을 때 Empty State 표시
- `ChatLayout.js`: 로딩 중 early return 제거 → 레이아웃 유지하며 채팅창 Skeleton 표시
- `ResourceHub.js`: 파일/링크 목록 로딩 시 Skeleton UI, 목록 없을 때 Empty State 표시
- `ExploreServers.js`: 서버 목록 로딩 시 카드 Skeleton UI, 검색 결과 없을 때 Empty State 표시

## ✅ 체크리스트
- [x] `README.md`에 명시된 코딩 컨벤션 및 커밋 메시지 규칙을 준수했습니다.
- [x] 관련 없는 코드나 불필요한 주석을 포함하지 않았습니다.
- [x] 작업할 브랜치(예: `dev`)의 최신 상태를 pull 받아 충돌이 없는 것을 확인했습니다.
- [ ] (Backend) 람다 함수나 DB 스키마 변경 시 로컬/테스트 환경에서 검증을 완료했습니다.

## 💬 리뷰어에게
- 로딩 속도가 빠른 경우 Skeleton이 잠깐 보이므로 크롬 개발자 도구 Network 탭에서 Slow 3G로 설정 후 확인하면 됩니다.
- 검색 Empty State는 서버 탐색 화면에서 존재하지 않는 검색어 입력 시 확인 가능합니다.