### PR TITLE
Fix: 이미 멤버인 서버 재입장 시 참여자 수 중복 카운트 방지

### DIFF
--- a/backend/src/chat/chatHandler.js
+++ b/backend/src/chat/chatHandler.js
@@ -16,6 +16,7 @@ const dynamoDb = require("../dynamodbClient");
 const SERVERS_TABLE     = process.env.SERVERS_TABLE;
 const CONNECTIONS_TABLE = process.env.CONNECTIONS_TABLE;
 const MESSAGES_TABLE    = process.env.MESSAGES_TABLE;
+const SERVER_MEMBERS_TABLE = process.env.SERVER_MEMBERS_TABLE;
 
 
 // =========================
@@ -163,15 +164,27 @@ async function joinServer(connectionId, body, event) {
     ExpressionAttributeValues: { ":r": serverId, ":u": userId },
   }));
 
-  // 2. 방 인원 +1
-  await dynamoDb.send(new UpdateCommand({
-    TableName:                 SERVERS_TABLE,
-    Key:                       { serverId },
-    UpdateExpression:          "SET currentCount = currentCount + :inc",
-    ExpressionAttributeValues: { ":inc": 1 },
-  }));
+  // 2. ServerMembers 테이블에서 이미 멤버인지 확인
+  let isAlreadyMember = false;
+  if (SERVER_MEMBERS_TABLE && userId) {
+    const memberResult = await dynamoDb.send(new GetCommand({
+      TableName: SERVER_MEMBERS_TABLE,
+      Key: { userId, serverId },
+    })).catch(() => null);
+    isAlreadyMember = Boolean(memberResult?.Item);
+  }
 
-  // 3. 같은 서버 모든 접속자 조회
+  // 3. 이미 멤버가 아닐 때만 currentCount +1
+  if (!isAlreadyMember) {
+    await dynamoDb.send(new UpdateCommand({
+      TableName:                 SERVERS_TABLE,
+      Key:                       { serverId },
+      UpdateExpression:          "SET currentCount = if_not_exists(currentCount, :zero) + :inc",
+      ExpressionAttributeValues: { ":inc": 1, ":zero": 0 },
+    }));
+  }
+
+  // 4. 같은 서버 모든 접속자 조회
   const response = await dynamoDb.send(new QueryCommand({
     TableName: CONNECTIONS_TABLE,
     IndexName: "serverId-index",
@@ -180,7 +193,7 @@ async function joinServer(connectionId, body, event) {
   }));
   const connections = response.Items || [];
 
-  // 4. 본인에게 현재 온라인 유저 ID 리스트 전송 (자기 포함)
+  // 5. 본인에게 현재 온라인 유저 ID 리스트 전송 (자기 포함)
   const onlineUserIds = [...new Set(
     connections.map((c) => c.userId).filter(Boolean)
   )];
@@ -203,7 +216,7 @@ async function joinServer(connectionId, body, event) {
 
   return {
     statusCode: 200,
-    body: JSON.stringify({ action: "joinServer", serverId }),
+    body: JSON.stringify({ action: "joinServer", serverId, isAlreadyMember }),
   };
 }
 

--- a/frontend/src/components/Servers/ExploreServers.js
+++ b/frontend/src/components/Servers/ExploreServers.js
@@ -49,7 +49,7 @@ const EmptySearchState = ({ query }) => (
   </div>
 );
 
-const ServerCard = ({ server, onJoin }) => {
+const ServerCard = ({ server, onJoin, isMember }) => {
   const name = getServerName(server, "제목 없음");
   const description = server.description;
   const currentMembers = Number(server.currentCount) || 0;
@@ -101,8 +101,9 @@ const ServerCard = ({ server, onJoin }) => {
           ) : isFull ? (
             <button className="servers-btn btn-locked" disabled>FULL</button>
           ) : (
+            // ✅ 이미 멤버면 "입장", 아니면 "JOIN"
             <button className="servers-btn btn-join" onClick={() => onJoin(server)}>
-              JOIN
+              {isMember ? "입장" : "JOIN"}
             </button>
           )}
         </div>
@@ -114,7 +115,7 @@ const ServerCard = ({ server, onJoin }) => {
 const ExploreServers = () => {
   const navigate = useNavigate();
   const { logout, refreshToken, user } = useAuth();
-  const { clearJoinedServers, setActiveServerId, upsertJoinedServer, removeJoinedServer } = useServers();
+  const { clearJoinedServers, setActiveServerId, upsertJoinedServer, removeJoinedServer, joinedServers  } = useServers();
   const [servers, setServers] = useState([]);
   const [loading, setLoading] = useState(true); // ✅ 로딩 상태 추가
   const [searchQuery, setSearchQuery] = useState("");
@@ -170,11 +171,27 @@ const ExploreServers = () => {
     );
   });
 
+  // ✅ 이미 가입한 서버인지 확인
+  const isAlreadyMember = (server) => {
+    const sid = getServerId(server);
+    return joinedServers.some((s) => getServerId(s) === sid);
+  };
+
   const executeJoin = async (server, password = null) => {
     const sid = getServerId(server);
+
+    // ✅ 이미 멤버면 joinServer API 호출 없이 바로 이동
+    if (isAlreadyMember(server)) {
+      navigate(getServerPath(sid));
+      return;
+    }
+
     try {
-      await joinServer(sid, password);
-      upsertJoinedServer(normalizeServer(server));
+      const result = await joinServer(sid, password);
+       // ✅ 백엔드에서 alreadyMember 응답도 중복 카운트 방지
+      if (!result?.alreadyMember) {
+        upsertJoinedServer(normalizeServer(server));
+      }
       navigate(getServerPath(sid));
     } catch (error) {
       console.error("서버 참여 실패:", error);
@@ -183,6 +200,12 @@ const ExploreServers = () => {
   };
 
   const handleJoinClick = (server) => {
+    // ✅ 이미 멤버면 비밀번호 없이 바로 입장
+    if (isAlreadyMember(server)) {
+      executeJoin(server);
+      return;
+    }
+
     if (server.isPrivate) {
       setSelectedServer(server);
       setIsJoinModalOpen(true);
@@ -331,6 +354,7 @@ const ExploreServers = () => {
                 key={getServerId(server)}
                 server={server}
                 onJoin={handleJoinClick}
+                isMember={isAlreadyMember(server)}
               />
             ))
           )}


### PR DESCRIPTION
## 📌 관련 이슈
#(이슈 번호)

## 🏷️ 작업 유형 (Type of Change)
- [ ] ✨ 기능 추가 (Feature)
- [x] 🐛 버그 수정 (Fix)
- [ ] 🎨 UI/UX 및 디자인 변경 (Design)
- [ ] ♻️ 리팩토링 (Refactor)
- [ ] 📝 문서 작업 (Docs)

## 🚀 작업 내용
- `chatHandler.js`: WebSocket joinServer 액션 시 ServerMembers 테이블에서 이미 멤버인지 확인 후 currentCount 증가 여부 결정
- `ExploreServers.js`: joinedServers 목록 기반으로 이미 멤버인 서버는 joinServer API 호출 없이 바로 입장, 버튼 텍스트 "입장"으로 변경

## ✅ 체크리스트
- [x] README.md에 명시된 코딩 컨벤션 및 커밋 메시지 규칙을 준수했습니다.
- [x] 관련 없는 코드나 불필요한 주석을 포함하지 않았습니다.
- [x] 작업할 브랜치(예: dev)의 최신 상태를 pull 받아 충돌이 없는 것을 확인했습니다.
- [x] (Backend) 람다 함수나 DB 스키마 변경 시 로컬/테스트 환경에서 검증을 완료했습니다.

## 💬 리뷰어에게
- 프론트: joinedServers 컨텍스트 기반으로 이미 가입한 서버 판별
- 백엔드: ServerMembers 테이블 조회로 중복 카운트 이중 방어
