### PR TITLE
Feat: AI 분석 SQS 비동기 패턴 도입 + moderation/invites 백엔드 배포

### DIFF
--- a/backend/deploy.sh
+++ b/backend/deploy.sh
@@ -19,6 +19,8 @@ MEMORY=512
 # ── 공통 환경 변수 ─────────────────────────────────────
 WSS_ENDPOINT="https://hxdwy4fqsg.execute-api.${REGION}.amazonaws.com/${STAGE}"
 
+AI_QUEUE_URL="https://sqs.${REGION}.amazonaws.com/269578498605/${PREFIX}-ai-analysis-queue"
+
 ENV_VARS="{
   \"Variables\": {
     \"REGION\":               \"${REGION}\",
@@ -32,7 +34,8 @@ ENV_VARS="{
     \"S3_BUCKET\":            \"inhatc-team3-2-resources\",
     \"JWT_SECRET_KEY\":       \"PLACEHOLDER\",
     \"SALT\":                 \"PLACEHOLDER\",
-    \"WSS_ENDPOINT\":         \"${WSS_ENDPOINT}\"
+    \"WSS_ENDPOINT\":         \"${WSS_ENDPOINT}\",
+    \"AI_QUEUE_URL\":         \"${AI_QUEUE_URL}\"
   }
 }"
 
@@ -57,6 +60,7 @@ FUNCTIONS=(
   "${PREFIX}-${STAGE}-joinServer|src/servers/joinServer.handler"
   "${PREFIX}-${STAGE}-getMyServers|src/servers/getMyServers.handler"
   "${PREFIX}-${STAGE}-updateChannel|src/servers/updateChannel.handler"
+  "${PREFIX}-${STAGE}-aiSubmit|src/ai/aiSubmit.handler"
 )
 
 # ── 1단계: 코드 패키징 + S3 업로드 ────────────────────────

--- a/backend/deploy.sh
+++ b/backend/deploy.sh
@@ -36,6 +36,7 @@ ENV_VARS="{
     \"SALT\":                 \"PLACEHOLDER\",
     \"WSS_ENDPOINT\":         \"${WSS_ENDPOINT}\",
     \"AI_QUEUE_URL\":         \"${AI_QUEUE_URL}\"
+    \"INVITES_TABLE\":        \"${PREFIX}-Invites\"
   }
 }"
 
@@ -61,6 +62,12 @@ FUNCTIONS=(
   "${PREFIX}-${STAGE}-getMyServers|src/servers/getMyServers.handler"
   "${PREFIX}-${STAGE}-updateChannel|src/servers/updateChannel.handler"
   "${PREFIX}-${STAGE}-aiSubmit|src/ai/aiSubmit.handler"
+  "${PREFIX}-${STAGE}-listMembers|src/moderation/listMembers.handler"
+  "${PREFIX}-${STAGE}-kickMember|src/moderation/kickMember.handler"
+  "${PREFIX}-${STAGE}-banMember|src/moderation/banMember.handler"
+  "${PREFIX}-${STAGE}-unbanMember|src/moderation/unbanMember.handler"
+  "${PREFIX}-${STAGE}-updateMemberRole|src/moderation/updateMemberRole.handler"
+  "${PREFIX}-${STAGE}-transferOwnership|src/moderation/transferOwnership.handler"
 )
 
 # ── 1단계: 코드 패키징 + S3 업로드 ────────────────────────

--- a/backend/deploy.sh
+++ b/backend/deploy.sh
@@ -68,6 +68,12 @@ FUNCTIONS=(
   "${PREFIX}-${STAGE}-unbanMember|src/moderation/unbanMember.handler"
   "${PREFIX}-${STAGE}-updateMemberRole|src/moderation/updateMemberRole.handler"
   "${PREFIX}-${STAGE}-transferOwnership|src/moderation/transferOwnership.handler"
+  "${PREFIX}-${STAGE}-createInvite|src/invites/createInvite.handler"
+  "${PREFIX}-${STAGE}-listInvites|src/invites/listInvites.handler"
+  "${PREFIX}-${STAGE}-deleteInvite|src/invites/deleteInvite.handler"
+  "${PREFIX}-${STAGE}-resetInvites|src/invites/resetInvites.handler"
+  "${PREFIX}-${STAGE}-validateInvite|src/invites/validateInvite.handler"
+  "${PREFIX}-${STAGE}-joinByInvite|src/invites/joinByInvite.handler"
 )
 
 # ── 1단계: 코드 패키징 + S3 업로드 ────────────────────────

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -13,6 +13,7 @@
         "@aws-sdk/client-dynamodb": "^3.1021.0",
         "@aws-sdk/client-rekognition": "^3.1029.0",
         "@aws-sdk/client-s3": "^3.1029.0",
+        "@aws-sdk/client-sqs": "^3.1045.0",
         "@aws-sdk/client-textract": "^3.1029.0",
         "@aws-sdk/client-translate": "^3.1029.0",
         "@aws-sdk/lib-dynamodb": "^3.1021.0",
@@ -516,7 +517,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.1021.0.tgz",
       "integrity": "sha512-Yp7p5HZh4ZAOqV7kbOP8ClPGJxFUTm+FRYLQAsA3x22rB3Q+rgcr+avBNxjS2AX7NeRCI6LY4zoeVYvILWEq3Q==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
@@ -842,6 +842,58 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-sqs": {
+      "version": "3.1045.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sqs/-/client-sqs-3.1045.0.tgz",
+      "integrity": "sha512-reWeEE53mgCv8uUFSicvVf0A6BoWGImdC4y5x5clkeEmfIikahIBtons6u0d32kwI4NczpcretpUkOCE/nvWAA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/credential-provider-node": "^3.972.39",
+        "@aws-sdk/middleware-host-header": "^3.972.10",
+        "@aws-sdk/middleware-logger": "^3.972.10",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.11",
+        "@aws-sdk/middleware-sdk-sqs": "^3.972.22",
+        "@aws-sdk/middleware-user-agent": "^3.972.38",
+        "@aws-sdk/region-config-resolver": "^3.972.13",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-endpoints": "^3.996.8",
+        "@aws-sdk/util-user-agent-browser": "^3.972.10",
+        "@aws-sdk/util-user-agent-node": "^3.973.24",
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/core": "^3.23.17",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/hash-node": "^4.2.14",
+        "@smithy/invalid-dependency": "^4.2.14",
+        "@smithy/md5-js": "^4.2.14",
+        "@smithy/middleware-content-length": "^4.2.14",
+        "@smithy/middleware-endpoint": "^4.4.32",
+        "@smithy/middleware-retry": "^4.5.7",
+        "@smithy/middleware-serde": "^4.2.20",
+        "@smithy/middleware-stack": "^4.2.14",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/node-http-handler": "^4.6.1",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.49",
+        "@smithy/util-defaults-mode-node": "^4.2.54",
+        "@smithy/util-endpoints": "^3.4.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.6",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@aws-sdk/client-sts": {
       "version": "3.1018.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.1018.0.tgz",
@@ -994,13 +1046,13 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.974.6",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.6.tgz",
-      "integrity": "sha512-8Vu7zGxu+39ChR/s5J7nXBw3a2kMHAi0OfKT8ohgTVjX0qYed/8mIfdBb638oBmKrWCwwKjYAM5J/4gMJ8nAJA==",
+      "version": "3.974.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.8.tgz",
+      "integrity": "sha512-njR2qoG6ZuB0kvAS2FyICsFZJ6gmCcf2X/7JcD14sUvGDm26wiZ5BrA6LOiUxKFEF+IVe7kdroxyE00YlkiYsw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.973.8",
-        "@aws-sdk/xml-builder": "^3.972.20",
+        "@aws-sdk/xml-builder": "^3.972.22",
         "@smithy/core": "^3.23.17",
         "@smithy/node-config-provider": "^4.3.14",
         "@smithy/property-provider": "^4.2.14",
@@ -1010,7 +1062,7 @@
         "@smithy/types": "^4.14.1",
         "@smithy/util-base64": "^4.3.2",
         "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-retry": "^4.3.5",
+        "@smithy/util-retry": "^4.3.6",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -1032,12 +1084,12 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.32",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.32.tgz",
-      "integrity": "sha512-7vA4GHg8NSmQxquJHSBcSM3RgB4ZaaRi6u4+zGFKOmOH6aqlgr2Sda46clkZDYzlirgfY96w15Zj0jh6PT48ng==",
+      "version": "3.972.34",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.34.tgz",
+      "integrity": "sha512-XT0jtf8Fw9JE6ppsQeoNnZRiG+jqRixMT1v1ZR17G60UvVdsQmTG8nbEyHuEPfMxDXEhfdARaM/XiEhca4lGHQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.6",
+        "@aws-sdk/core": "^3.974.8",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/property-provider": "^4.2.14",
         "@smithy/types": "^4.14.1",
@@ -1048,12 +1100,12 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.34",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.34.tgz",
-      "integrity": "sha512-vBrhWujFCLp1u8ptJRWYlipMutzPptb8pDQ00rKVH9q67T7rGd3VTWIj63aKrlLuY6qSsw1Rt5F/D/7wnNgryA==",
+      "version": "3.972.36",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.36.tgz",
+      "integrity": "sha512-DPoGWfy7J7RKxvbf5kOKIGQkD2ek3dbKgzKIGrnLuvZBz5myU+Im/H6pmc14QcnFbqHMqxvtWSgRDSJW3qXLQg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.6",
+        "@aws-sdk/core": "^3.974.8",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/fetch-http-handler": "^5.3.17",
         "@smithy/node-http-handler": "^4.6.1",
@@ -1069,19 +1121,19 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.972.36",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.36.tgz",
-      "integrity": "sha512-FBHyCmV8EB0gUvh1d+CZm87zt2PrdC7OyWexLRoH3I5zWSOUGa+9t58Y5jbxRfwUp3AWpHAFvKY6YzgR845sVA==",
+      "version": "3.972.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.38.tgz",
+      "integrity": "sha512-oDzUBu2MGJFgoar05sPMCwSrhw44ASyccrHzj66vO69OZqi7I6hZZxXfuPLC8OCzW7C+sU+bI73XHij41yekgQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.6",
-        "@aws-sdk/credential-provider-env": "^3.972.32",
-        "@aws-sdk/credential-provider-http": "^3.972.34",
-        "@aws-sdk/credential-provider-login": "^3.972.36",
-        "@aws-sdk/credential-provider-process": "^3.972.32",
-        "@aws-sdk/credential-provider-sso": "^3.972.36",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.36",
-        "@aws-sdk/nested-clients": "^3.997.4",
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/credential-provider-env": "^3.972.34",
+        "@aws-sdk/credential-provider-http": "^3.972.36",
+        "@aws-sdk/credential-provider-login": "^3.972.38",
+        "@aws-sdk/credential-provider-process": "^3.972.34",
+        "@aws-sdk/credential-provider-sso": "^3.972.38",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.38",
+        "@aws-sdk/nested-clients": "^3.997.6",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/credential-provider-imds": "^4.2.14",
         "@smithy/property-provider": "^4.2.14",
@@ -1094,13 +1146,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.36",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.36.tgz",
-      "integrity": "sha512-IFap01lJKxQc0C/OHmZwZQr/cKq0DhrcmKedRrdnnl42D+P0SImnnnWQjv07uIPqpEdtqmkPXb9TiPYTU+prxQ==",
+      "version": "3.972.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.38.tgz",
+      "integrity": "sha512-g1NosS8qe4OF++G2UFCM5ovSkgipC7YYor5KCWatG0UoMSO5YFj9C8muePlyVmOBV/WTI16Jo3/s1NUo/o1Bww==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.6",
-        "@aws-sdk/nested-clients": "^3.997.4",
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/nested-clients": "^3.997.6",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/property-provider": "^4.2.14",
         "@smithy/protocol-http": "^5.3.14",
@@ -1113,17 +1165,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.37",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.37.tgz",
-      "integrity": "sha512-/WFixFAAiw8WpmjZcI0l4t3DerXLmVinOIfuotmRZnu2qmsFPoqqmstASz0z8bi1pGdFXzeLzf6bwucM3mZcUQ==",
+      "version": "3.972.39",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.39.tgz",
+      "integrity": "sha512-HEswDQyxUtadoZ/bJsPPENHg7R0Lzym5LuMksJeHvqhCOpP+rtkDLKI4/ZChH4w3cf5kG8n6bZuI8PzajoiqMg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.32",
-        "@aws-sdk/credential-provider-http": "^3.972.34",
-        "@aws-sdk/credential-provider-ini": "^3.972.36",
-        "@aws-sdk/credential-provider-process": "^3.972.32",
-        "@aws-sdk/credential-provider-sso": "^3.972.36",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.36",
+        "@aws-sdk/credential-provider-env": "^3.972.34",
+        "@aws-sdk/credential-provider-http": "^3.972.36",
+        "@aws-sdk/credential-provider-ini": "^3.972.38",
+        "@aws-sdk/credential-provider-process": "^3.972.34",
+        "@aws-sdk/credential-provider-sso": "^3.972.38",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.38",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/credential-provider-imds": "^4.2.14",
         "@smithy/property-provider": "^4.2.14",
@@ -1136,12 +1188,12 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.32",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.32.tgz",
-      "integrity": "sha512-uZp4tlGbpczV8QxmtIwOpSkcyGtBRR8/T4BAumRKfAt1nwCig3FSCZvrKl6ARDIDVRYn5p2oRcAsfFR01EgMGA==",
+      "version": "3.972.34",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.34.tgz",
+      "integrity": "sha512-T3IFs4EVmVi1dVN5RciFnklCANSzvrQd/VuHY9ThHSQmYkTogjcGkoJEr+oNUPQZnso52183088NqysMPji1/Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.6",
+        "@aws-sdk/core": "^3.974.8",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/property-provider": "^4.2.14",
         "@smithy/shared-ini-file-loader": "^4.4.9",
@@ -1153,14 +1205,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.972.36",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.36.tgz",
-      "integrity": "sha512-DsLr0UHMyKzRJKe2bjlwU8q1cfoXg8TIJKV/xwvnalAemiZLOZunFzj/whGnFDZIBVLdnbLiwv5SvRf1+CSwkg==",
+      "version": "3.972.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.38.tgz",
+      "integrity": "sha512-5ZxG+t0+3Q3QPh8KEjX6syskhgNf7I0MN7oGioTf6Lm1NTjfP7sIcYGNsthXC2qR8vcD3edNZwCr2ovfSSWuRA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.6",
-        "@aws-sdk/nested-clients": "^3.997.4",
-        "@aws-sdk/token-providers": "3.1038.0",
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/nested-clients": "^3.997.6",
+        "@aws-sdk/token-providers": "3.1041.0",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/property-provider": "^4.2.14",
         "@smithy/shared-ini-file-loader": "^4.4.9",
@@ -1172,13 +1224,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.36",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.36.tgz",
-      "integrity": "sha512-uzrURO7frJhHQVVNR5zBJcCYeMYflmXcWBK1+MiBym2Dfjh6nXATrMixrmGZi+97Q7ETZ+y/4lUwAy0Nfnznjw==",
+      "version": "3.972.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.38.tgz",
+      "integrity": "sha512-lYHFF30DGI20jZcYX8cm6Ns0V7f1dDN6g/MBDLTyD/5iw+bXs3yBr2iAiHDkx4RFU5JgsnZvCHYKiRVPRdmOgw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.6",
-        "@aws-sdk/nested-clients": "^3.997.4",
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/nested-clients": "^3.997.6",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/property-provider": "^4.2.14",
         "@smithy/shared-ini-file-loader": "^4.4.9",
@@ -1420,12 +1472,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-s3": {
-      "version": "3.972.35",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.35.tgz",
-      "integrity": "sha512-lLppaNTAz+wNgLdi4FtHzrlwrGF0ODTnBWHBaFg85SKs0eJ+M+tP5ifrA8f/0lNd+Ak3MC1NGC6RavV3ny4HTg==",
+      "version": "3.972.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.37.tgz",
+      "integrity": "sha512-Km7M+i8DrLArVzrid1gfxeGhYHBd3uxvE77g0s5a52zPSVosxzQBnJ0gwWb6NIp/DOk8gsBMhi7V+cpJG0ndTA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.6",
+        "@aws-sdk/core": "^3.974.8",
         "@aws-sdk/types": "^3.973.8",
         "@aws-sdk/util-arn-parser": "^3.972.3",
         "@smithy/core": "^3.23.17",
@@ -1437,6 +1489,23 @@
         "@smithy/util-config-provider": "^4.2.2",
         "@smithy/util-middleware": "^4.2.14",
         "@smithy/util-stream": "^4.5.25",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-sqs": {
+      "version": "3.972.22",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sqs/-/middleware-sdk-sqs-3.972.22.tgz",
+      "integrity": "sha512-DtR3mEiOUJcnEX/QuXmvbJto6xvQzp2ftnHb29c0aQYdmmzbKf0gsu9ovx1i/yy4ZR6m0rttTucS0iiP32dlGA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-hex-encoding": "^4.2.2",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -1459,18 +1528,18 @@
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.972.36",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.36.tgz",
-      "integrity": "sha512-O2beToxguBvrZFFZ+fFgPbbae8MvyIBjQ6lImee4APHEXXNAD5ZJ2ayLF1mb7rsKw86TM81y5czg82bZncjSjg==",
+      "version": "3.972.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.38.tgz",
+      "integrity": "sha512-iz+B29TXcAZsJpwB+AwG/TTGA5l/VnmMZ2UxtiySOZjI6gCdmviXPwdgzcmuazMy16rXoPY4mYCGe7zdNKfx5A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.6",
+        "@aws-sdk/core": "^3.974.8",
         "@aws-sdk/types": "^3.973.8",
         "@aws-sdk/util-endpoints": "^3.996.8",
         "@smithy/core": "^3.23.17",
         "@smithy/protocol-http": "^5.3.14",
         "@smithy/types": "^4.14.1",
-        "@smithy/util-retry": "^4.3.5",
+        "@smithy/util-retry": "^4.3.6",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1501,24 +1570,24 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.997.4",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.4.tgz",
-      "integrity": "sha512-4Sf+WY1lMJzXlw5MiyCMe/UzdILCwvuaHThbqMXS6dfh9gZy3No360I42RXquOI/ULUOhWy2HCyU0Fp20fQGPQ==",
+      "version": "3.997.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.6.tgz",
+      "integrity": "sha512-WBDnqatJl+kGObpfmfSxqnXeYTu3Me8wx8WCtvoxX3pfWrrTv8I4WTMSSs7PZqcRcVh8WeUKMgGFjMG+52SR1w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.6",
+        "@aws-sdk/core": "^3.974.8",
         "@aws-sdk/middleware-host-header": "^3.972.10",
         "@aws-sdk/middleware-logger": "^3.972.10",
         "@aws-sdk/middleware-recursion-detection": "^3.972.11",
-        "@aws-sdk/middleware-user-agent": "^3.972.36",
+        "@aws-sdk/middleware-user-agent": "^3.972.38",
         "@aws-sdk/region-config-resolver": "^3.972.13",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.23",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.25",
         "@aws-sdk/types": "^3.973.8",
         "@aws-sdk/util-endpoints": "^3.996.8",
         "@aws-sdk/util-user-agent-browser": "^3.972.10",
-        "@aws-sdk/util-user-agent-node": "^3.973.22",
+        "@aws-sdk/util-user-agent-node": "^3.973.24",
         "@smithy/config-resolver": "^4.4.17",
         "@smithy/core": "^3.23.17",
         "@smithy/fetch-http-handler": "^5.3.17",
@@ -1526,7 +1595,7 @@
         "@smithy/invalid-dependency": "^4.2.14",
         "@smithy/middleware-content-length": "^4.2.14",
         "@smithy/middleware-endpoint": "^4.4.32",
-        "@smithy/middleware-retry": "^4.5.6",
+        "@smithy/middleware-retry": "^4.5.7",
         "@smithy/middleware-serde": "^4.2.20",
         "@smithy/middleware-stack": "^4.2.14",
         "@smithy/node-config-provider": "^4.3.14",
@@ -1542,7 +1611,7 @@
         "@smithy/util-defaults-mode-node": "^4.2.54",
         "@smithy/util-endpoints": "^3.4.2",
         "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-retry": "^4.3.5",
+        "@smithy/util-retry": "^4.3.6",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -1586,12 +1655,12 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.23",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.23.tgz",
-      "integrity": "sha512-wBbys3Y53Ikly556vyADurKpYQHXS7Jjaskbz+Ga9PZCz7PB/9f3VdKbDlz7dqIzn+xwz7L/a6TR4iXcOi8IRw==",
+      "version": "3.996.25",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.25.tgz",
+      "integrity": "sha512-+CMIt3e1VzlklAECmG+DtP1sV8iKq25FuA0OKpnJ4KA0kxUtd7CgClY7/RU6VzJBQwbN4EJ9Ue6plvqx1qGadw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-sdk-s3": "^3.972.35",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.37",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/protocol-http": "^5.3.14",
         "@smithy/signature-v4": "^5.3.14",
@@ -1603,13 +1672,13 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.1038.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1038.0.tgz",
-      "integrity": "sha512-Qniru+9oGGb/HNK/gGZWbV3jsD0k71ngE7qMQ/x6gYNYLd2EOwHCS6E2E6jfkaqO4i0d+nNKmfRy8bNcshKdGQ==",
+      "version": "3.1041.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1041.0.tgz",
+      "integrity": "sha512-Th7kPI6YPtvJUcdznooXJMy+9rQWjmEF81LxaJssngBzuysK4a/x+l8kjm1zb7nYsUPbndnBdUnwng/3PLvtGw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.6",
-        "@aws-sdk/nested-clients": "^3.997.4",
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/nested-clients": "^3.997.6",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/property-provider": "^4.2.14",
         "@smithy/shared-ini-file-loader": "^4.4.9",
@@ -1716,12 +1785,12 @@
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.973.22",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.22.tgz",
-      "integrity": "sha512-YTYqTmOUrwbm1h99Ee4y/mVYpFRl0oSO/amtP5cc1BZZWdaAVWs9zj3TkyRHWvR9aI/ZS8m3mS6awXtYUlWyaw==",
+      "version": "3.973.24",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.24.tgz",
+      "integrity": "sha512-ZWwlkjcIp7cEL8ZfTpTAPNkwx25p7xol0xlKoWVVf22+nsjwmLcHYtTPjIV1cSpmB/b6DaK4cb1fSkvCXHgRdw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-user-agent": "^3.972.36",
+        "@aws-sdk/middleware-user-agent": "^3.972.38",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/node-config-provider": "^4.3.14",
         "@smithy/types": "^4.14.1",
@@ -1741,9 +1810,9 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.21",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.21.tgz",
-      "integrity": "sha512-qxNiHUtlrsjTeSlrPWiFkWps7uD6YB4eKzg7eLAFH8jbiHTlt0ePNlo2Xu+WlftP38JIcMaIX4jTUjOlE2ySWw==",
+      "version": "3.972.22",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.22.tgz",
+      "integrity": "sha512-PMYKKtJd70IsSG0yHrdAbxBr+ZWBKLvzFZfD3/urxgf6hXVMzuU5M+3MJ5G67RpOmLBu1fAUN65SbWuKUCOlAA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@nodable/entities": "2.1.0",
@@ -2602,20 +2671,13 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.23.17",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.17.tgz",
-      "integrity": "sha512-x7BlLbUFL8NWCGjMF9C+1N5cVCxcPa7g6Tv9B4A2luWx3be3oU8hQ96wIwxe/s7OhIzvoJH73HAUSg5JXVlEtQ==",
+      "version": "3.24.1",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.1.tgz",
+      "integrity": "sha512-3mT7o4qQyUWttYnVK3A0Z/u3Xha3E81tXn32Tz6vjZiUXhBrkEivpw1hBYfh84iFF9CSzkBU9Y1DJ3Q6RQ231g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.14",
+        "@aws-crypto/crc32": "5.2.0",
         "@smithy/types": "^4.14.1",
-        "@smithy/url-parser": "^4.2.14",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-body-length-browser": "^4.2.2",
-        "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-stream": "^4.5.25",
-        "@smithy/util-utf8": "^4.2.2",
-        "@smithy/uuid": "^1.1.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2794,13 +2856,12 @@
       }
     },
     "node_modules/@smithy/md5-js": {
-      "version": "4.2.13",
-      "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-4.2.13.tgz",
-      "integrity": "sha512-cNm7I9NXolFxtS20ojROddOEpSAeI1Obq6pd1Kj5HtHws3s9Fkk8DdHDfQSs5KuxCewZuVK6UqrJnfJmiMzDuQ==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-4.3.1.tgz",
+      "integrity": "sha512-98NalujRdzv6ggVQNYPWpL2K57UKeUB8roIr61u6+JiHd7KUlMQ+sn/vk6IG4XxEjw2vlC7eu/xjYXshUE4XXg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.0",
-        "@smithy/util-utf8": "^4.2.2",
+        "@smithy/core": "^3.24.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5896,9 +5957,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
-      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
       "funding": [
         {
           "type": "github",
@@ -5907,7 +5968,8 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "path-expression-matcher": "^1.1.3"
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
       }
     },
     "node_modules/fast-xml-parser": {
@@ -7409,7 +7471,6 @@
       "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 10.16.0"
       }
@@ -7859,7 +7920,6 @@
       "integrity": "sha512-ek8NRg/OPvS9ISOJNWNAz5vZcpYacWNFDWNJjj5OXsc6YuKacfey6wF04cXz/tOJIVrZ2nGSkHpAY5qKtF6ISg==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "d": "^1.0.2",
         "duration": "^0.2.2",
@@ -9394,7 +9454,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@aws-sdk/client-api-gateway": "^3.588.0",
         "@aws-sdk/client-cognito-identity-provider": "^3.588.0",
@@ -9991,9 +10050,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
-      "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
       "funding": [
         {
           "type": "github",
@@ -10842,7 +10901,6 @@
       "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8.3.0"
       },
@@ -10857,6 +10915,21 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/xml2js": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -18,6 +18,7 @@
     "@aws-sdk/client-dynamodb": "^3.1021.0",
     "@aws-sdk/client-rekognition": "^3.1029.0",
     "@aws-sdk/client-s3": "^3.1029.0",
+    "@aws-sdk/client-sqs": "^3.1045.0",
     "@aws-sdk/client-textract": "^3.1029.0",
     "@aws-sdk/client-translate": "^3.1029.0",
     "@aws-sdk/lib-dynamodb": "^3.1021.0",

--- a/backend/src/ai/aiRouter.js
+++ b/backend/src/ai/aiRouter.js
@@ -7,7 +7,6 @@ const { PutCommand, QueryCommand } = require("@aws-sdk/lib-dynamodb");
 const { ApiGatewayManagementApiClient, PostToConnectionCommand } = require("@aws-sdk/client-apigatewaymanagementapi");
 const { v4: uuidv4 } = require("uuid");
 const dynamoDb = require("../dynamodbClient");
-const { HEADERS } = require("../utils/response");
 
 const REGION = process.env.REGION || "us-east-1";
 const RESOURCES_BUCKET = process.env.RESOURCES_BUCKET;
@@ -15,7 +14,7 @@ const RESOURCES_BUCKET = process.env.RESOURCES_BUCKET;
 // DB 테이블명 및 웹소켓 엔드포인트 환경변수
 const MESSAGES_TABLE = process.env.MESSAGES_TABLE;
 const CONNECTIONS_TABLE = process.env.CONNECTIONS_TABLE;
-const WSS_ENDPOINT = process.env.WSS_ENDPOINT; // HTTP 핸들러이므로 환경변수로 주입받아야 합니다.
+const WSS_ENDPOINT = process.env.WSS_ENDPOINT;
 
 const textract    = new TextractClient({ region: REGION });
 const rekognition = new RekognitionClient({ region: REGION });
@@ -57,146 +56,155 @@ async function summarizeWithBedrock(text) {
   return responseBody.content[0].text;
 }
 
+// =========================
+// SQS 트리거 핸들러
+// =========================
 exports.handler = async (event) => {
-  try {
-    const body = JSON.parse(event.body || "{}");
-    const { s3ObjectKey, fileType, serverId, fileName, requestId } = body;
+  const records = event.Records || [];
 
-    if (!s3ObjectKey || !fileType) {
-      return {
-        statusCode: 400,
-        headers: HEADERS,
-        body: JSON.stringify({ message: "s3ObjectKey, fileType은 필수입니다." }),
-      };
+  if (records.length === 0) {
+    console.warn("aiRouter: 처리할 SQS 메시지가 없습니다.");
+    return { statusCode: 200 };
+  }
+
+  // BatchSize=1로 설정 예정이지만, 혹시 모르니 루프 처리
+  for (const record of records) {
+    try {
+      const body = JSON.parse(record.body || "{}");
+      await processAiAnalysis(body);
+    } catch (error) {
+      console.error("aiRouter 메시지 처리 실패:", error);
+      // throw하면 SQS가 VisibilityTimeout 후 재시도 (maxReceiveCount까지)
+      throw error;
     }
+  }
 
-    let result = {};
+  return { statusCode: 200 };
+};
 
-    // ── 1. PDF/문서 → Textract + Bedrock 요약 ──
-    if (fileType.includes("pdf") || fileType.includes("document")) {
-      const textractResponse = await textract.send(new StartDocumentTextDetectionCommand({
-        DocumentLocation: { S3Object: { Bucket: RESOURCES_BUCKET, Name: s3ObjectKey } },
-      }));
-      const extractedText = await waitForTextract(textractResponse.JobId);
-      const summary = await summarizeWithBedrock(extractedText);
+// =========================
+// AI 분석 메인 로직
+// =========================
+async function processAiAnalysis(body) {
+  const { s3ObjectKey, fileType, serverId, fileName, requestId } = body;
 
-      result = {
-        type: "document",
-        status: "COMPLETE",
-        fileName: fileName || s3ObjectKey.split("/").pop(),
-        extractedText: extractedText.slice(0, 2000),
-        summary,
-      };
-    }
-    // ── 2. 이미지 → Rekognition + Translate ──
-    else if (fileType.startsWith("image/")) {
-      const labelsResponse = await rekognition.send(new DetectLabelsCommand({
-        Image: { S3Object: { Bucket: RESOURCES_BUCKET, Name: s3ObjectKey } },
-        MaxLabels: 10,
-        MinConfidence: 70,
-      }));
-      const labels = labelsResponse.Labels.map(l => ({ name: l.Name, confidence: Math.round(l.Confidence) }));
+  // 검증 실패는 재시도 의미 없음. 로그만 남기고 종료.
+  if (!s3ObjectKey || !fileType) {
+    console.warn("aiRouter 필수 파라미터 누락:", { s3ObjectKey, fileType });
+    return;
+  }
 
-      const textResponse = await rekognition.send(new DetectTextCommand({
-        Image: { S3Object: { Bucket: RESOURCES_BUCKET, Name: s3ObjectKey } },
-      }));
-      const detectedTexts = textResponse.TextDetections.filter(t => t.Type === "LINE").map(t => t.DetectedText);
+  console.log("aiRouter 분석 시작:", { s3ObjectKey, fileType, serverId, requestId });
 
-      const labelNames = labels.map(l => l.name).join(", ");
-      let labelsKo = [];
-      if (labelNames) {
-        const translateResponse = await translate.send(new TranslateTextCommand({
-          Text: labelNames, SourceLanguageCode: "en", TargetLanguageCode: "ko",
-        }));
-        labelsKo = translateResponse.TranslatedText.split(", ");
-      }
+  let result = {};
 
-      result = {
-        type: "image",
-        status: "COMPLETE",
-        fileName: fileName || s3ObjectKey.split("/").pop(),
-        labels, labelsKo, detectedTexts,
-      };
-    } else {
-      result = {
-        type: "unsupported",
-        status: "SKIPPED",
-        message: "지원하지 않는 파일 형식입니다. (PDF, 이미지만 분석 가능)",
-      };
-    }
+  // ── 1. PDF/문서 → Textract + Bedrock 요약 ──
+  if (fileType.includes("pdf") || fileType.includes("document")) {
+    const textractResponse = await textract.send(new StartDocumentTextDetectionCommand({
+      DocumentLocation: { S3Object: { Bucket: RESOURCES_BUCKET, Name: s3ObjectKey } },
+    }));
+    const extractedText = await waitForTextract(textractResponse.JobId);
+    const summary = await summarizeWithBedrock(extractedText);
 
-    // ── [추가된 로직] DB에 메시지 저장 및 브로드캐스트 ──
-    if (serverId && result.status === "COMPLETE") {
-      const messageId = uuidv4();
-      const createdAt = new Date().toISOString();
-
-      // 프론트엔드 ChatWindow에 맞게 데이터 구조화
-      const messageItem = {
-        serverId,
-        messageId,
-        senderId: "system-ai",         // 고정된 AI ID
-        senderNickname: "AI 스터디 조교", // 대화창에 표시될 이름
-        messageType: "ai-summary",     // 프론트엔드 CSS 트리거용 타입
-        content: JSON.stringify(result), // 결과 객체를 문자열로 담음 (프론트에서 JSON.parse)
-        createdAt,
-        ...(requestId && { aiRequestId: requestId }),
-      };
-
-      // 1. Messages 테이블에 저장
-      await dynamoDb.send(new PutCommand({
-        TableName: MESSAGES_TABLE,
-        Item: messageItem,
-      }));
-
-      // 2. 같은 방(serverId) 접속자에게 실시간 브로드캐스트
-      if (WSS_ENDPOINT) {
-        const apigw = new ApiGatewayManagementApiClient({ endpoint: WSS_ENDPOINT });
-        
-        const response = await dynamoDb.send(new QueryCommand({
-          TableName: CONNECTIONS_TABLE,
-          IndexName: "serverId-index",
-          KeyConditionExpression: "serverId = :serverId",
-          ExpressionAttributeValues: { ":serverId": serverId },
-        }));
-
-        const connections = response.Items || [];
-
-        await Promise.all(
-          connections.map(async (conn) => {
-            try {
-              await apigw.send(new PostToConnectionCommand({
-                ConnectionId: conn.connectionId,
-                Data: Buffer.from(JSON.stringify({
-                  action: "receiveMessage",
-                  data: messageItem
-                })),
-              }));
-            } catch (err) {
-              console.log(`Failed to send AI summary to connection: ${conn.connectionId}`);
-              // 연결이 끊겼거나 문제가 생긴 커넥션은 무시 (chatHandler와 동일 로직)
-            }
-          })
-        );
-      } else {
-        console.warn("WSS_ENDPOINT가 설정되지 않아 브로드캐스트를 생략합니다.");
-      }
-    }
-
-    return {
-      statusCode: 200,
-      headers: HEADERS,
-      body: JSON.stringify({
-        message: "AI 분석 완료 및 채팅방 전송 성공",
-        serverId: serverId || null,
-        s3ObjectKey,
-      }),
-    };
-  } catch (error) {
-    console.error("AI Router Error:", error);
-    return {
-      statusCode: 500,
-      headers: HEADERS,
-      body: JSON.stringify({ message: "AI 분석 실패", error: error.message }),
+    result = {
+      type: "document",
+      status: "COMPLETE",
+      fileName: fileName || s3ObjectKey.split("/").pop(),
+      extractedText: extractedText.slice(0, 2000),
+      summary,
     };
   }
-};
+  // ── 2. 이미지 → Rekognition + Translate ──
+  else if (fileType.startsWith("image/")) {
+    const labelsResponse = await rekognition.send(new DetectLabelsCommand({
+      Image: { S3Object: { Bucket: RESOURCES_BUCKET, Name: s3ObjectKey } },
+      MaxLabels: 10,
+      MinConfidence: 70,
+    }));
+    const labels = labelsResponse.Labels.map(l => ({ name: l.Name, confidence: Math.round(l.Confidence) }));
+
+    const textResponse = await rekognition.send(new DetectTextCommand({
+      Image: { S3Object: { Bucket: RESOURCES_BUCKET, Name: s3ObjectKey } },
+    }));
+    const detectedTexts = textResponse.TextDetections.filter(t => t.Type === "LINE").map(t => t.DetectedText);
+
+    const labelNames = labels.map(l => l.name).join(", ");
+    let labelsKo = [];
+    if (labelNames) {
+      const translateResponse = await translate.send(new TranslateTextCommand({
+        Text: labelNames, SourceLanguageCode: "en", TargetLanguageCode: "ko",
+      }));
+      labelsKo = translateResponse.TranslatedText.split(", ");
+    }
+
+    result = {
+      type: "image",
+      status: "COMPLETE",
+      fileName: fileName || s3ObjectKey.split("/").pop(),
+      labels, labelsKo, detectedTexts,
+    };
+  } else {
+    result = {
+      type: "unsupported",
+      status: "SKIPPED",
+      message: "지원하지 않는 파일 형식입니다. (PDF, 이미지만 분석 가능)",
+    };
+  }
+
+  // ── DB에 메시지 저장 및 브로드캐스트 ──
+  if (serverId && result.status === "COMPLETE") {
+    const messageId = uuidv4();
+    const createdAt = new Date().toISOString();
+
+    const messageItem = {
+      serverId,
+      messageId,
+      senderId: "system-ai",
+      senderNickname: "AI 스터디 조교",
+      messageType: "ai-summary",
+      content: JSON.stringify(result),
+      createdAt,
+      ...(requestId && { aiRequestId: requestId }),
+    };
+
+    // 1. Messages 테이블에 저장
+    await dynamoDb.send(new PutCommand({
+      TableName: MESSAGES_TABLE,
+      Item: messageItem,
+    }));
+
+    // 2. 같은 서버 접속자에게 실시간 브로드캐스트
+    if (WSS_ENDPOINT) {
+      const apigw = new ApiGatewayManagementApiClient({ endpoint: WSS_ENDPOINT });
+
+      const response = await dynamoDb.send(new QueryCommand({
+        TableName: CONNECTIONS_TABLE,
+        IndexName: "serverId-index",
+        KeyConditionExpression: "serverId = :serverId",
+        ExpressionAttributeValues: { ":serverId": serverId },
+      }));
+
+      const connections = response.Items || [];
+
+      await Promise.all(
+        connections.map(async (conn) => {
+          try {
+            await apigw.send(new PostToConnectionCommand({
+              ConnectionId: conn.connectionId,
+              Data: Buffer.from(JSON.stringify({
+                action: "receiveMessage",
+                data: messageItem,
+              })),
+            }));
+          } catch (err) {
+            console.log(`AI 결과 전송 실패 (정상): ${conn.connectionId}`);
+          }
+        })
+      );
+    } else {
+      console.warn("WSS_ENDPOINT가 설정되지 않아 브로드캐스트를 생략합니다.");
+    }
+
+    console.log("aiRouter 분석 완료:", { messageId, serverId, requestId });
+  }
+}

--- a/backend/src/ai/aiSubmit.js
+++ b/backend/src/ai/aiSubmit.js
@@ -1,0 +1,65 @@
+const { SQSClient, SendMessageCommand } = require("@aws-sdk/client-sqs");
+const { HEADERS } = require("../utils/response");
+
+const REGION = process.env.REGION || "us-east-1";
+const AI_QUEUE_URL = process.env.AI_QUEUE_URL;
+
+const sqs = new SQSClient({ region: REGION });
+
+exports.handler = async (event) => {
+  try {
+    const body = JSON.parse(event.body || "{}");
+    const { s3ObjectKey, fileType, serverId, fileName, requestId } = body;
+
+    // 필수 파라미터 검증
+    if (!s3ObjectKey || !fileType) {
+      return {
+        statusCode: 400,
+        headers: HEADERS,
+        body: JSON.stringify({ message: "s3ObjectKey, fileType은 필수입니다." }),
+      };
+    }
+
+    if (!AI_QUEUE_URL) {
+      console.error("AI_QUEUE_URL 환경변수가 설정되지 않았습니다.");
+      return {
+        statusCode: 500,
+        headers: HEADERS,
+        body: JSON.stringify({ message: "서버 설정 오류" }),
+      };
+    }
+
+    // SQS에 작업 enqueue
+    await sqs.send(new SendMessageCommand({
+      QueueUrl: AI_QUEUE_URL,
+      MessageBody: JSON.stringify({
+        s3ObjectKey,
+        fileType,
+        serverId,
+        fileName,
+        requestId,
+        submittedAt: new Date().toISOString(),
+      }),
+    }));
+
+    // 즉시 202 Accepted 응답
+    return {
+      statusCode: 202,
+      headers: HEADERS,
+      body: JSON.stringify({
+        message: "AI 분석 요청이 접수되었습니다. 완료되면 채팅창에 자동으로 결과가 표시됩니다.",
+        requestId,
+      }),
+    };
+  } catch (error) {
+    console.error("aiSubmit 오류:", error);
+    return {
+      statusCode: 500,
+      headers: HEADERS,
+      body: JSON.stringify({
+        message: "AI 분석 요청 처리 중 오류가 발생했습니다.",
+        error: error.message,
+      }),
+    };
+  }
+};


### PR DESCRIPTION
## 📌 관련 이슈
없음. 아키텍처 다이어그램의 "SQS AI 대기열" 미구현 항목 실제 구현 + ROADMAP의 BackEnd [완료]로 표시되어 있었으나 실제 미배포 상태였던 moderation/invites 모듈 배포 완료.

## 🏷️ 작업 유형 (Type of Change)
- [x] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Fix)
- [ ] 🎨 UI/UX 및 디자인 변경 (Design)
- [x] ♻️ 리팩토링 (Refactor)
- [ ] 📝 문서 작업 (Docs)

## 🚀 작업 내용

### 1. AI 분석 SQS 비동기 큐 패턴 도입

#### 배경
- REST API `/ai/analyze` → aiRouter Lambda 동기 호출
- API Gateway 29초 타임아웃 vs 실제 분석 1~5분 → 504 Gateway Timeout
- 프론트엔드 catch 블록으로 504 무시하는 우회 패턴
- 아키텍처 다이어그램의 "SQS AI 대기열"이 실제 미구현

#### 변경 아키텍처

**Before:**REST /ai/analyze → aiRouter Lambda (1~5분) ❌ 29초 타임아웃

**After:**REST /ai/analyze → aiSubmit Lambda (즉시 202 응답)
↓ SQS enqueue
[smartstudy-ai-analysis-queue]
↓ Event Source Mapping
aiRouter Lambda (백그라운드)
↓ Textract + Bedrock
DynamoDB + WebSocket 결과 전송(3회 실패 시)
[smartstudy-ai-analysis-dlq] — 14일 보관

#### 변경 사항

**백엔드 코드**
- `backend/src/ai/aiSubmit.js` (신규): REST → SQS enqueue 전담 (58줄)
- `backend/src/ai/aiRouter.js`: HTTP 핸들러 → SQS 트리거 핸들러 (183줄)

**인프라**
- SQS 메인 큐 신규: `smartstudy-ai-analysis-queue` (VisibilityTimeout 360s)
- SQS DLQ 신규: `smartstudy-ai-analysis-dlq` (보관 14일, maxReceiveCount=3)
- aiRouter Lambda Timeout 300s → 360s (VisibilityTimeout과 일치)
- Event Source Mapping: SQS → aiRouter (BatchSize=1, Enabled)
- API Gateway `/ai/analyze` 통합 대상: aiRouter → aiSubmit

### 2. X-Ray 분산 트레이싱 활성화

- 전체 20개 Lambda에 `TracingConfig.Mode=Active` 일괄 적용
- SQS / DynamoDB / API Gateway / Lambda 호출 흐름 추적 가능
- 학부 환경 권한 제약으로 본인이 트레이스 조회는 불가하나, Lambda → CloudWatch X-Ray 발송은 정상 동작

### 3. CloudWatch Alarm + SNS 알림 채널

- SNS Topic 신규: `smartstudy-alerts` (이메일 구독)
- 알람 3개:
  - DLQ에 메시지 1건 이상 누적 시 알림
  - aiSubmit Lambda 에러율 (5분 내 3회 이상)
  - aiRouter Lambda 에러율 (5분 내 3회 이상)

### 4. moderation 모듈 배포 (6개 Lambda + API 경로)

ROADMAP에 BackEnd [완료]로 표시되어 있었으나 실제 AWS 미배포 상태였던 모듈을 배포 완료.

| 메서드 | 경로 | Lambda | 권한 |
|------|------|--------|------|
| GET | `/servers/{serverId}/members` | listMembers | MEMBER |
| PATCH | `/servers/{serverId}/members/{targetUserId}/role` | updateMemberRole | HOST |
| POST | `/servers/{serverId}/members/{targetUserId}/kick` | kickMember | MODERATOR |
| POST | `/servers/{serverId}/members/{targetUserId}/ban` | banMember | MODERATOR |
| DELETE | `/servers/{serverId}/bans/{targetUserId}` | unbanMember | MODERATOR |
| POST | `/servers/{serverId}/ownership` | transferOwnership | HOST |

### 5. invites 모듈 배포 (6개 Lambda + API 경로 + DynamoDB 테이블)

| 메서드 | 경로 | Lambda |
|------|------|--------|
| POST | `/servers/{serverId}/invites` | createInvite |
| GET | `/servers/{serverId}/invites` | listInvites |
| DELETE | `/servers/{serverId}/invites/{inviteId}` | deleteInvite |
| POST | `/servers/{serverId}/invites/reset` | resetInvites |
| GET | `/invites/{inviteCode}` | validateInvite |
| POST | `/invites/{inviteCode}/join` | joinByInvite |

**DynamoDB 테이블 신규: `smartstudy-Invites`**
- HASH key: inviteId
- GSI: inviteCode-index, serverId-createdAt-index
- TTL: expiresAt (자동 만료 처리)

### 6. deploy.sh 업데이트

신규 Lambda 13개 (aiSubmit + moderation 6 + invites 6) FUNCTIONS 배열에 추가, `INVITES_TABLE`, `AI_QUEUE_URL` 환경변수 주입.

## 동작 검증

### SQS 비동기 패턴
- ✅ aiSubmit 응답 시간: 평균 ~60ms (즉시 202)
- ✅ aiRouter 처리 시간: 11~12초 (PDF 1페이지)
- ✅ SQS 메시지 흐름 정상 (대기 → 처리 중 → 완료)
- ✅ DLQ 0건 (실패 없음)
- ✅ 동시 분석 요청 시 두 Lambda 인스턴스 병렬 처리
- ✅ 브라우저 콘솔의 504 에러 사라짐

### moderation/invites API
- ✅ 12개 신규 Lambda 모두 Active 상태
- ✅ API Gateway 12개 경로 + 메서드 + Lambda 통합 + 권한 모두 정상
- ✅ DynamoDB Invites 테이블 + GSI 2개 + TTL 모두 ACTIVE

## ✅ 체크리스트
- [x] `README.md`에 명시된 코딩 컨벤션 및 커밋 메시지 규칙 준수
- [x] 관련 없는 코드/주석 미포함
- [x] dev 브랜치 최신 상태 pull 후 충돌 없음 확인
- [x] CloudShell 통합 테스트로 SQS → aiRouter 흐름 종단 간 검증
- [x] moderation/invites API 12개 경로 모두 생성 및 권한 설정 완료

## 💬 리뷰어에게

### 아키텍처 다이어그램 정합성
다이어그램에 그려져 있던 "SQS AI 대기열"이 이번 PR로 실제 구현됐습니다. 다이어그램과 인프라가 일치합니다.

### 운영 메모

#### SQS 관련
- VisibilityTimeout = Lambda Timeout = 360초 (일치 필수)
- maxReceiveCount=3 → 3회 실패 시 DLQ로 자동 이동
- BatchSize=1 → AI 분석은 무거운 작업이라 인스턴스당 1메시지로 격리

#### 신규 리소스 ID 메모
**SQS:**
- 메인 큐 ARN: `arn:aws:sqs:us-east-1:269578498605:smartstudy-ai-analysis-queue`
- DLQ ARN: `arn:aws:sqs:us-east-1:269578498605:smartstudy-ai-analysis-dlq`
- Event Source Mapping UUID: `d379d43a-e0d0-4cef-b748-88cd4c31c7c2`

**SNS:**
- Topic ARN: `arn:aws:sns:us-east-1:269578498605:smartstudy-alerts`

**API Gateway 신규 부모 리소스 ID (추후 작업 참조용):**
- /servers/{serverId}/members: `osqj3b`
- /servers/{serverId}/members/{targetUserId}: `hpvlil`
- /servers/{serverId}/invites: `d3bvg3`
- /invites: `cdsa3s`

### 향후 작업 후보
- Lambda Reserved Concurrency로 Bedrock 비용 제어
- CloudFront + HTTPS (시연용 자물쇠)
- moderation/invites에 추가 통합 테스트 시나리오