### PR TITLE
Feat: 초대 코드 관리 UI 및 입장 프로세스 연동

### DIFF
--- a/frontend/src/components/Chat/ChatLayout.js
+++ b/frontend/src/components/Chat/ChatLayout.js
@@ -332,6 +332,8 @@ const ChatLayout = () => {
         fields={createServerFields(createServerDefaultValues(currentServer || {}))}
         onClose={closeSettingsModal}
         onSubmit={handleServerSettingsSubmit}
+        serverId={serverId}
+        isHost={isCurrentUserHost}
       />
 
       <EntitySettingsModal

--- a/frontend/src/components/Servers/ExploreServers.js
+++ b/frontend/src/components/Servers/ExploreServers.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { getServerPath } from "../../constants/path";
-import { getServers, joinServer, updateServer, leaveServer, deleteServer } from "../../lib/servers";
+import { getServers, joinServer, updateServer, leaveServer, deleteServer, validateInvite, joinByInvite } from "../../lib/servers";
 import "./ExploreServers.css";
 import ServerSidebar from "../layout/ServerSidebar";
 import CreateServerModal from "./CreateServerModal";
@@ -221,10 +221,35 @@ const ExploreServers = () => {
     }
   };
 
-  const handleDirectJoin = () => {
-    if (!inviteCode.trim()) {
-      toast.info("입력 필요", "코드 혹은 주소를 입력해주세요.");
+  // ✅ 초대 코드로 즉시 입장
+  const handleDirectJoin = async () => {
+    const code = inviteCode.trim().toUpperCase();
+    if (!code) {
+      toast.info("입력 필요", "초대 코드를 입력해주세요.");
       return;
+    }
+    try {
+      const validation = await validateInvite(code);
+      if (!validation.valid) {
+        toast.error("유효하지 않은 코드", validation.message || "유효하지 않은 초대 코드입니다.");
+        return;
+      }
+      const { serverId: targetServerId } = validation.invite;
+ 
+      if (isAlreadyMember({ serverId: targetServerId })) {
+        navigate(getServerPath(targetServerId));
+        return;
+      }
+ 
+      const result = await joinByInvite(code);
+      if (result.alreadyMember) {
+        navigate(getServerPath(targetServerId));
+        return;
+      }
+      toast.success("입장 완료", `${validation.invite.serverName} 서버에 입장했습니다.`);
+      navigate(getServerPath(targetServerId));
+    } catch (error) {
+      toast.error("입장 실패", error.message || "초대 코드 입장에 실패했습니다.");
     }
   };
 
@@ -342,6 +367,7 @@ const ExploreServers = () => {
             placeholder="초대 코드 또는 URL 입력"
             value={inviteCode}
             onChange={(e) => setInviteCode(e.target.value)}
+            onKeyDown={(e) => { if (e.key === "Enter") handleDirectJoin(); }}
           />
           <button className="join-directly-btn" onClick={handleDirectJoin}>
             즉시 입장
@@ -401,6 +427,8 @@ const ExploreServers = () => {
         )}
         onClose={closeSettingsModal}
         onSubmit={handleServerSettingsSubmit}
+        serverId={getServerId(settingsModal?.server)}
+        isHost={user?.userId === settingsModal?.server?.hostId}
       />
 
       <ConfirmModal

--- a/frontend/src/components/common/EntitySettingsModal.js
+++ b/frontend/src/components/common/EntitySettingsModal.js
@@ -1,5 +1,7 @@
-import React from "react";
+import React, { useState } from "react";
 import FormModal from "./FormModal";
+import InviteManager from "./InviteManager";
+import "./InviteManager.css";
 
 function EntitySettingsModal({
   open,
@@ -11,24 +13,80 @@ function EntitySettingsModal({
   cancelLabel = "취소",
   onClose,
   onSubmit,
+  // ✅ 초대 코드 탭용 props
+  serverId,
+  isHost,
 }) {
-  const resolvedTitle =
-    entityType === "channel" ? "채널 설정" : "서버 설정";
+  const [activeTab, setActiveTab] = useState("settings");
+  const resolvedTitle = entityType === "channel" ? "채널 설정" : "서버 설정";
+
+  // 채널 설정이거나 초대 코드 탭 비활성화 시 기존 FormModal 그대로
+  if (entityType === "channel") {
+    return (
+      <FormModal
+        open={open}
+        title={resolvedTitle}
+        description={description || `${entityName || "현재 항목"}의 정보를 수정하고 저장할 수 있습니다.`}
+        fields={fields}
+        submitLabel={submitLabel}
+        cancelLabel={cancelLabel}
+        onClose={onClose}
+        onSubmit={onSubmit}
+      />
+    );
+  }
+
+  if (!open) return null;
 
   return (
-    <FormModal
-      open={open}
-      title={resolvedTitle}
-      description={
-        description ||
-        `${entityName || "현재 항목"}의 정보를 수정하고 저장할 수 있습니다.`
-      }
-      fields={fields}
-      submitLabel={submitLabel}
-      cancelLabel={cancelLabel}
-      onClose={onClose}
-      onSubmit={onSubmit}
-    />
+    <div className="form-modal__overlay" onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}>
+      <div className="form-modal" style={{ maxWidth: 560 }}>
+        <button type="button" className="form-modal__close" onClick={onClose} aria-label="모달 닫기">✕</button>
+
+        <div className="form-modal__header">
+          <h2>{resolvedTitle}</h2>
+          {/* ✅ 탭 */}
+          <div className="entity-settings-tabs">
+            <button
+              type="button"
+              className={`entity-settings-tab ${activeTab === "settings" ? "active" : ""}`}
+              onClick={() => setActiveTab("settings")}
+            >
+              기본 설정
+            </button>
+            <button
+              type="button"
+              className={`entity-settings-tab ${activeTab === "invites" ? "active" : ""}`}
+              onClick={() => setActiveTab("invites")}
+            >
+              🔗 초대 코드
+            </button>
+          </div>
+        </div>
+
+        {activeTab === "settings" ? (
+          <FormModal
+            open={true}
+            title=""
+            description={description || `${entityName || "현재 항목"}의 정보를 수정하고 저장할 수 있습니다.`}
+            fields={fields}
+            submitLabel={submitLabel}
+            cancelLabel={cancelLabel}
+            onClose={onClose}
+            onSubmit={onSubmit}
+            _embedded
+          />
+        ) : (
+          <div style={{ padding: "0 24px 24px" }}>
+            {serverId ? (
+              <InviteManager serverId={serverId} />
+            ) : (
+              <p style={{ color: "#52525b", fontSize: "13px" }}>서버 정보를 불러올 수 없습니다.</p>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
   );
 }
 

--- a/frontend/src/components/common/FormModal.css
+++ b/frontend/src/components/common/FormModal.css
@@ -334,3 +334,34 @@
     width: 100%;
   }
 }
+
+/* ── EntitySettingsModal 탭 ── */
+.entity-settings-tabs {
+  display: flex;
+  gap: 2px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+  margin-top: 16px;
+}
+
+.entity-settings-tab {
+  background: none;
+  border: none;
+  color: #71717a;
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  padding: 10px 16px;
+  cursor: pointer;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+  transition: color 0.2s, border-color 0.2s;
+}
+
+.entity-settings-tab:hover {
+  color: #d4d4d8;
+}
+
+.entity-settings-tab.active {
+  color: #ffffff;
+  border-bottom-color: #00ff66;
+}

--- a/frontend/src/components/common/FormModal.js
+++ b/frontend/src/components/common/FormModal.js
@@ -41,6 +41,7 @@ function FormModal({
   cancelLabel = "취소",
   onClose,
   onSubmit,
+  _embedded = false, // ✅ EntitySettingsModal 내부 임베드 시 overlay/헤더 숨김
 }) {
   const initialValues = useMemo(() => buildInitialValues(fields), [fields]);
   const [values, setValues] = useState(initialValues);
@@ -48,13 +49,13 @@ function FormModal({
   const [submitError, setSubmitError] = useState("");
 
   useEffect(() => {
-    if (open) {
+    if (open || _embedded) {
       setValues(initialValues);
       setSubmitError("");
     }
-  }, [initialValues, open]);
+  }, [initialValues, open, _embedded]);
 
-  if (!open) {
+  if (!open && !_embedded) {
     return null;
   }
 
@@ -66,7 +67,6 @@ function FormModal({
           nextValues[field.name] = field.defaultValue ?? (field.type === "file" ? null : "");
         }
       });
-
       return nextValues;
     });
   };
@@ -193,73 +193,48 @@ function FormModal({
     );
   };
 
+  const formBody = (
+    <form className="form-modal__form" onSubmit={handleSubmit}>
+      {_embedded && description && <p style={{ fontSize: "13px", color: "#a1a1aa", margin: "0 0 12px" }}>{description}</p>}
+      <div className="form-modal__grid">
+        {fields
+          .filter((field) => !field.showIf || field.showIf(values))
+          .map((field) => (
+            <div key={field.name} className={`form-modal__group ${field.width === "half" ? "form-modal__group--half" : ""}`}>
+              <label htmlFor={field.name}>{field.label}</label>
+              {renderField(field)}
+              {field.helperText && <span className="form-modal__helper">{field.helperText}</span>}
+            </div>
+          ))}
+      </div>
+      <div className="form-modal__footer">
+        {submitError ? <p className="form-modal__error">{submitError}</p> : <span className="form-modal__error-spacer" />}
+        <div className="form-modal__actions">
+          <button type="button" className="form-modal__button form-modal__button--ghost" onClick={onClose}>{cancelLabel}</button>
+          <button type="submit" className="form-modal__button form-modal__button--primary" disabled={isSubmitting}>
+            {isSubmitting ? "저장 중..." : submitLabel}
+          </button>
+        </div>
+      </div>
+    </form>
+  );
+ 
+  // ✅ 임베드 모드: overlay/헤더/닫기 버튼 없이 폼만 렌더링
+  if (_embedded) return formBody;
+ 
   return (
     <div className="form-modal__overlay" onClick={handleOverlayClick}>
       <div className="form-modal">
-        <button
-          type="button"
-          className="form-modal__close"
-          onClick={onClose}
-          aria-label="모달 닫기"
-          disabled={isSubmitting}
-        >
-          ✕
-        </button>
-
+        <button type="button" className="form-modal__close" onClick={onClose} aria-label="모달 닫기" disabled={isSubmitting}>✕</button>
         <div className="form-modal__header">
           <h2>{title}</h2>
-          {description ? <p>{description}</p> : null}
+          {description && <p>{description}</p>}
         </div>
-
-        <form className="form-modal__form" onSubmit={handleSubmit}>
-          <div className="form-modal__grid">
-            {fields
-              .filter((field) => {
-                if(!field.showIf) return true;
-                return field.showIf(values);
-              })
-              .map((field) => (
-                <div
-                  key={field.name}
-                  className={`form-modal__group ${field.width === "half" ? "form-modal__group--half" : ""}`}
-                >
-                  <label htmlFor={field.name}>{field.label}</label>
-                  {renderField(field)}
-                  {field.helperText ? (
-                    <span className="form-modal__helper">{field.helperText}</span>
-                  ) : null}
-                </div>
-              ))
-            }
-          </div>
-
-          <div className="form-modal__footer">
-            {submitError ? (
-              <p className="form-modal__error">{submitError}</p>
-            ) : (
-              <span className="form-modal__error-spacer" />
-            )}
-            <div className="form-modal__actions">
-              <button
-                type="button"
-                className="form-modal__button form-modal__button--ghost"
-                onClick={onClose}
-              >
-                {cancelLabel}
-              </button>
-              <button
-                type="submit"
-                className="form-modal__button form-modal__button--primary"
-                disabled={isSubmitting}
-              >
-                {isSubmitting ? "저장 중..." : submitLabel}
-              </button>
-            </div>
-          </div>
-        </form>
+        {formBody}
       </div>
     </div>
   );
 }
-
+ 
+    
 export default FormModal;

--- a/frontend/src/components/common/InviteManager.css
+++ b/frontend/src/components/common/InviteManager.css
@@ -1,0 +1,215 @@
+/* ── 초대 코드 관리 ── */
+.invite-manager {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  padding: 4px 0;
+}
+
+.invite-section-title {
+  font-size: 12px;
+  font-weight: 700;
+  color: #71717a;
+  letter-spacing: 1px;
+  margin: 0 0 10px;
+}
+
+/* 생성 영역 */
+.invite-create-box {
+  background: #18181b;
+  border: 1px solid #27272a;
+  border-radius: 10px;
+  padding: 16px;
+}
+
+.invite-options {
+  display: flex;
+  align-items: flex-end;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.invite-option-group {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  flex: 1;
+  min-width: 120px;
+}
+
+.invite-option-group label {
+  font-size: 11px;
+  color: #a1a1aa;
+  font-weight: 600;
+}
+
+.invite-option-group select {
+  background: #09090b;
+  border: 1px solid #3f3f46;
+  border-radius: 6px;
+  color: #fff;
+  padding: 8px 10px;
+  font-size: 13px;
+  outline: none;
+  cursor: pointer;
+}
+
+.invite-option-group select:focus {
+  border-color: #00ff66;
+}
+
+.invite-create-btn {
+  background: #00ff66;
+  color: #000;
+  border: none;
+  border-radius: 6px;
+  padding: 9px 16px;
+  font-size: 13px;
+  font-weight: 700;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.2s;
+  align-self: flex-end;
+}
+
+.invite-create-btn:hover:not(:disabled) {
+  background: #00e55c;
+}
+
+.invite-create-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* 목록 영역 */
+.invite-list-box {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.invite-list-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.invite-reset-btn {
+  background: none;
+  border: 1px solid #3f3f46;
+  border-radius: 6px;
+  color: #71717a;
+  padding: 4px 10px;
+  font-size: 11px;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.invite-reset-btn:hover {
+  border-color: #ef4444;
+  color: #ef4444;
+}
+
+.invite-loading {
+  font-size: 13px;
+  color: #52525b;
+  padding: 12px;
+  text-align: center;
+}
+
+.invite-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  padding: 24px;
+  color: #52525b;
+  font-size: 13px;
+  background: #18181b;
+  border-radius: 10px;
+  border: 1px dashed #27272a;
+}
+
+.invite-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.invite-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  background: #18181b;
+  border: 1px solid #27272a;
+  border-radius: 8px;
+  padding: 10px 14px;
+}
+
+.invite-code-badge {
+  font-family: monospace;
+  font-size: 15px;
+  font-weight: 700;
+  color: #00ff66;
+  letter-spacing: 2px;
+  background: rgba(0, 255, 102, 0.08);
+  padding: 4px 10px;
+  border-radius: 6px;
+  flex-shrink: 0;
+}
+
+.invite-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  flex: 1;
+  min-width: 0;
+}
+
+.invite-meta span {
+  font-size: 11px;
+  color: #71717a;
+}
+
+.invite-actions {
+  display: flex;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.invite-copy-btn {
+  background: none;
+  border: 1px solid #3f3f46;
+  border-radius: 6px;
+  color: #d4d4d8;
+  padding: 4px 10px;
+  font-size: 12px;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.invite-copy-btn:hover {
+  border-color: #00ff66;
+  color: #00ff66;
+}
+
+.invite-copy-btn.copied {
+  border-color: #00ff66;
+  color: #00ff66;
+}
+
+.invite-delete-btn {
+  background: none;
+  border: 1px solid #3f3f46;
+  border-radius: 6px;
+  color: #71717a;
+  padding: 4px 10px;
+  font-size: 12px;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.invite-delete-btn:hover {
+  border-color: #ef4444;
+  color: #ef4444;
+}

--- a/frontend/src/components/common/InviteManager.js
+++ b/frontend/src/components/common/InviteManager.js
@@ -1,0 +1,188 @@
+import React, { useState, useEffect, useCallback } from "react";
+import { listInvites, createInvite, deleteInvite, resetInvites } from "../../lib/servers";
+import { useToast } from "../../contexts/ToastContext";
+
+const EXPIRES_OPTIONS = [
+  { label: "24시간", value: 24 },
+  { label: "7일", value: 24 * 7 },
+  { label: "30일", value: 24 * 30 },
+];
+
+const MAX_USES_OPTIONS = [
+  { label: "무제한", value: "" },
+  { label: "1회", value: 1 },
+  { label: "5회", value: 5 },
+  { label: "10회", value: 10 },
+  { label: "25회", value: 25 },
+];
+
+function formatExpiry(expiresAt) {
+  if (!expiresAt) return "-";
+  const date = new Date(expiresAt * 1000);
+  return date.toLocaleString("ko-KR", { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" });
+}
+
+function copyToClipboard(text) {
+  navigator.clipboard?.writeText(text).catch(() => {
+    const el = document.createElement("textarea");
+    el.value = text;
+    document.body.appendChild(el);
+    el.select();
+    document.execCommand("copy");
+    document.body.removeChild(el);
+  });
+}
+
+const InviteManager = ({ serverId }) => {
+  const toast = useToast();
+  const [invites, setInvites] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [creating, setCreating] = useState(false);
+  const [expiresInHours, setExpiresInHours] = useState(24 * 7);
+  const [maxUses, setMaxUses] = useState("");
+  const [copiedCode, setCopiedCode] = useState("");
+
+  const fetchInvites = useCallback(async () => {
+    try {
+      setLoading(true);
+      const result = await listInvites(serverId);
+      setInvites(result.items || []);
+    } catch (error) {
+      console.error("초대 코드 목록 조회 실패:", error);
+      toast.error("조회 실패", "초대 코드 목록을 불러오지 못했습니다.");
+    } finally {
+      setLoading(false);
+    }
+  }, [serverId, toast]);
+
+  useEffect(() => {
+    fetchInvites();
+  }, [fetchInvites]);
+
+  const handleCreate = async () => {
+    setCreating(true);
+    try {
+      const options = { expiresInHours: Number(expiresInHours) };
+      if (maxUses !== "") options.maxUses = Number(maxUses);
+      const result = await createInvite(serverId, options);
+      setInvites((prev) => [result.invite, ...prev]);
+      toast.success("생성 완료", `초대 코드 ${result.invite.inviteCode}가 생성되었습니다.`);
+    } catch (error) {
+      toast.error("생성 실패", error.message || "초대 코드 생성에 실패했습니다.");
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  const handleDelete = async (inviteId) => {
+    if (!window.confirm("초대 코드를 삭제하시겠습니까?")) return;
+    try {
+      await deleteInvite(serverId, inviteId);
+      setInvites((prev) => prev.filter((i) => i.inviteId !== inviteId));
+      toast.success("삭제 완료", "초대 코드가 삭제되었습니다.");
+    } catch (error) {
+      toast.error("삭제 실패", error.message || "초대 코드 삭제에 실패했습니다.");
+    }
+  };
+
+  const handleReset = async () => {
+    if (!window.confirm("모든 초대 코드를 초기화하시겠습니까?")) return;
+    try {
+      await resetInvites(serverId);
+      setInvites([]);
+      toast.success("초기화 완료", "모든 초대 코드가 삭제되었습니다.");
+    } catch (error) {
+      toast.error("초기화 실패", error.message || "초대 코드 초기화에 실패했습니다.");
+    }
+  };
+
+  const handleCopy = (code) => {
+    copyToClipboard(code);
+    setCopiedCode(code);
+    toast.success("복사 완료", `초대 코드 ${code}가 클립보드에 복사되었습니다.`);
+    setTimeout(() => setCopiedCode(""), 2000);
+  };
+
+  return (
+    <div className="invite-manager">
+      {/* 생성 영역 */}
+      <div className="invite-create-box">
+        <h4 className="invite-section-title">새 초대 코드 생성</h4>
+        <div className="invite-options">
+          <div className="invite-option-group">
+            <label>유효 기간</label>
+            <select value={expiresInHours} onChange={(e) => setExpiresInHours(e.target.value)}>
+              {EXPIRES_OPTIONS.map((o) => (
+                <option key={o.value} value={o.value}>{o.label}</option>
+              ))}
+            </select>
+          </div>
+          <div className="invite-option-group">
+            <label>최대 사용 횟수</label>
+            <select value={maxUses} onChange={(e) => setMaxUses(e.target.value)}>
+              {MAX_USES_OPTIONS.map((o) => (
+                <option key={o.label} value={o.value}>{o.label}</option>
+              ))}
+            </select>
+          </div>
+          <button
+            className="invite-create-btn"
+            onClick={handleCreate}
+            disabled={creating}
+          >
+            {creating ? "생성 중..." : "+ 코드 생성"}
+          </button>
+        </div>
+      </div>
+
+      {/* 목록 영역 */}
+      <div className="invite-list-box">
+        <div className="invite-list-header">
+          <h4 className="invite-section-title">활성 초대 코드 {invites.length > 0 ? `(${invites.length})` : ""}</h4>
+          {invites.length > 0 && (
+            <button className="invite-reset-btn" onClick={handleReset}>
+              전체 초기화
+            </button>
+          )}
+        </div>
+
+        {loading ? (
+          <div className="invite-loading">불러오는 중...</div>
+        ) : invites.length === 0 ? (
+          <div className="invite-empty">
+            <span>🔗</span>
+            <p>활성 초대 코드가 없습니다</p>
+          </div>
+        ) : (
+          <div className="invite-list">
+            {invites.map((invite) => (
+              <div key={invite.inviteId} className="invite-item">
+                <div className="invite-code-badge">{invite.inviteCode}</div>
+                <div className="invite-meta">
+                  <span>만료: {formatExpiry(invite.expiresAt)}</span>
+                  <span>사용: {invite.useCount || 0}{invite.maxUses ? `/${invite.maxUses}` : ""}</span>
+                </div>
+                <div className="invite-actions">
+                  <button
+                    className={`invite-copy-btn ${copiedCode === invite.inviteCode ? "copied" : ""}`}
+                    onClick={() => handleCopy(invite.inviteCode)}
+                  >
+                    {copiedCode === invite.inviteCode ? "✓ 복사됨" : "복사"}
+                  </button>
+                  <button
+                    className="invite-delete-btn"
+                    onClick={() => handleDelete(invite.inviteId)}
+                  >
+                    삭제
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default InviteManager;

--- a/frontend/src/lib/servers.js
+++ b/frontend/src/lib/servers.js
@@ -35,7 +35,6 @@ export function leaveServer(serverId) {
   return request(`${ENDPOINTS.servers.list}/${serverId}/leave`, { method: "POST", });
 }
 
-// ✅ keyword 파라미터 추가
 export function getServerMessages(serverId, keyword) {
   const url = keyword?.trim()
     ? `${ENDPOINTS.servers.list}/${serverId}/messages?keyword=${encodeURIComponent(keyword.trim())}`
@@ -44,9 +43,7 @@ export function getServerMessages(serverId, keyword) {
 }
 
 export function joinServer(serverId, password) {
-  const options = {
-    method: "POST",
-  };
+  const options = { method: "POST", };
   if (password) {
     options.body = JSON.stringify({ serverPassword: password });
   }
@@ -75,3 +72,39 @@ export const updateChannel = async (serverId, chId, data) => {
     }),
   });
 };
+
+// ✅ 초대 코드 API
+export function listInvites(serverId) {
+  return request(`${ENDPOINTS.servers.list}/${serverId}/invites`, { method: "GET" });
+}
+ 
+export function createInvite(serverId, options = {}) {
+  return request(`${ENDPOINTS.servers.list}/${serverId}/invites`, {
+    method: "POST",
+    body: JSON.stringify(options),
+  });
+}
+ 
+export function deleteInvite(serverId, inviteId) {
+  return request(`${ENDPOINTS.servers.list}/${serverId}/invites/${inviteId}`, {
+    method: "DELETE",
+  });
+}
+ 
+export function resetInvites(serverId) {
+  return request(`${ENDPOINTS.servers.list}/${serverId}/invites/reset`, {
+    method: "POST",
+  });
+}
+ 
+export function validateInvite(inviteCode) {
+  return request(`/invites/${encodeURIComponent(inviteCode.trim().toUpperCase())}`, {
+    method: "GET",
+  });
+}
+ 
+export function joinByInvite(inviteCode) {
+  return request(`/invites/${encodeURIComponent(inviteCode.trim().toUpperCase())}/join`, {
+    method: "POST",
+  });
+}


### PR DESCRIPTION
## 📌 관련 이슈
#(이슈 번호)

## 🏷️ 작업 유형 (Type of Change)
- [x] ✨ 기능 추가 (Feature)
- [ ] 🐛 버그 수정 (Fix)
- [x] 🎨 UI/UX 및 디자인 변경 (Design)
- [ ] ♻️ 리팩토링 (Refactor)
- [ ] 📝 문서 작업 (Docs)

## 🚀 작업 내용
- `servers.js`: 초대 코드 관련 API 함수 추가 (`listInvites`, `createInvite`, `deleteInvite`, `resetInvites`, `validateInvite`, `joinByInvite`)
- `InviteManager.js`: 초대 코드 생성/목록/복사/삭제/전체 초기화 UI 컴포넌트
- `EntitySettingsModal.js`: 서버 설정 모달에 "기본 설정 / 🔗 초대 코드" 탭 추가
- `FormModal.js`: `_embedded` 모드 추가 (탭 내부 렌더링 시 overlay 없이 폼만 표시)
- `ExploreServers.js`: 초대 코드 입력창에서 `validateInvite` → `joinByInvite` 연동, Enter키 지원
- `ChatLayout.js`: `EntitySettingsModal`에 `serverId`, `isHost` prop 전달
- `FormModal.css`: 서버 설정 모달 탭 스타일을 리소스 허브 탭과 통일감 있게 수정

## ✅ 체크리스트
- [x] `README.md`에 명시된 코딩 컨벤션 및 커밋 메시지 규칙을 준수했습니다.
- [x] 관련 없는 코드나 불필요한 주석을 포함하지 않았습니다.
- [x] 작업할 브랜치(예: `dev`)의 최신 상태를 pull 받아 충돌이 없는 것을 확인했습니다.
- [x] (Backend) 람다 함수나 DB 스키마 변경 시 로컬/테스트 환경에서 검증을 완료했습니다.

## 💬 리뷰어에게
- 초대 코드는 유효 기간(24시간/7일/30일)과 최대 사용 횟수(무제한/1/5/10/25회) 옵션으로 생성 가능합니다.
- 비공개 서버도 초대 코드로 입장 시 비밀번호 없이 입장 가능합니다. (의도된 동작)
- 서버 설정창에서 초대 코드를 생성할 수 있습니다.