### PR TITLE
Fix: receiveMessage 수신 시 전송 중 상태 해제되지 않는 버그 수정

### DIFF
--- a/frontend/src/components/Chat/ChatWindow.js
+++ b/frontend/src/components/Chat/ChatWindow.js
@@ -249,6 +249,8 @@ const ChatWindow = ({ activeChannel, channels, sendWsMessage, isConnected, chatM
           ...nextMessages[existingIndex],
           ...message,
           isOptimistic: false,
+          sendStatus: undefined, // ✅ 추가 - "전송 중..." 상태 해제
+          sendError: undefined,  // ✅ 추가 - 에러 메시지 초기화
         };
 
         return {


### PR DESCRIPTION
## 📌 관련 이슈
#(이슈 번호)

## 🏷️ 작업 유형 (Type of Change)
- [ ] ✨ 기능 추가 (Feature)
- [x] 🐛 버그 수정 (Fix)
- [ ] 🎨 UI/UX 및 디자인 변경 (Design)
- [ ] ♻️ 리팩토링 (Refactor)
- [ ] 📝 문서 작업 (Docs)

## 🚀 작업 내용
- `ChatWindow.js`: receiveMessage 수신 시 Optimistic 메시지의 `sendStatus`, `sendError`를 `undefined`로 초기화하여 "전송 중..." 상태가 해제되지 않는 버그 수정

## ✅ 체크리스트
- [x] `README.md`에 명시된 코딩 컨벤션 및 커밋 메시지 규칙을 준수했습니다.
- [x] 관련 없는 코드나 불필요한 주석을 포함하지 않았습니다.
- [x] 작업할 브랜치(예: `dev`)의 최신 상태를 pull 받아 충돌이 없는 것을 확인했습니다.
- [x] (Backend) 람다 함수나 DB 스키마 변경 시 로컬/테스트 환경에서 검증을 완료했습니다.

## 💬 리뷰어에게
- 배포 환경에서 메시지 전송 후 "전송 중..." 상태가 계속 유지되는 버그를 수정했습니다.
- `appendMessageToChannel`에서 서버 응답 메시지로 교체 시 `sendStatus: undefined`, `sendError: undefined`를 명시적으로 초기화했습니다.
- 로컬에서는 WebSocket Forbidden 문제로 테스트 불가, 배포 환경에서 확인 필요합니다.