### PR TITLE
Feat: 프로필 수정 모달 구현

### DIFF
--- a/frontend/src/components/Profile/ProfileEditModal.css
+++ b/frontend/src/components/Profile/ProfileEditModal.css
@@ -1,0 +1,159 @@
+.profile-modal-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1200;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.66);
+  backdrop-filter: blur(2px);
+  padding: 16px;
+}
+
+.profile-modal-card {
+  width: min(460px, 100%);
+  background: #0f1115;
+  border: 1px solid #2a2f3a;
+  border-radius: 16px;
+  padding: 24px;
+  position: relative;
+  box-shadow: 0 20px 45px rgba(0, 0, 0, 0.45);
+}
+
+.profile-modal-close {
+  position: absolute;
+  top: 14px;
+  right: 14px;
+  border: 0;
+  background: transparent;
+  color: #9ca3af;
+  font-size: 17px;
+  cursor: pointer;
+}
+
+.profile-modal-title {
+  margin: 0;
+  color: #f9fafb;
+  font-size: 22px;
+}
+
+.profile-modal-description {
+  margin: 8px 0 18px;
+  color: #9ca3af;
+  font-size: 14px;
+}
+
+.profile-modal-form {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.profile-modal-avatar-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.profile-modal-avatar-image,
+.profile-modal-avatar-fallback {
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  border: 1px solid #334155;
+}
+
+.profile-modal-avatar-image {
+  object-fit: cover;
+}
+
+.profile-modal-avatar-fallback {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #d1fae5;
+  background: #14532d;
+  font-weight: 800;
+  font-size: 22px;
+}
+
+.profile-modal-upload-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px 14px;
+  border-radius: 10px;
+  border: 1px solid #2d3748;
+  color: #e5e7eb;
+  background: #1f2937;
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 600;
+}
+
+#profile-image-input {
+  display: none;
+}
+
+.profile-modal-label {
+  color: #e5e7eb;
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.profile-modal-input {
+  width: 100%;
+  height: 42px;
+  border-radius: 10px;
+  border: 1px solid #2d3748;
+  background: #111827;
+  color: #f3f4f6;
+  padding: 0 12px;
+  font-size: 14px;
+}
+
+.profile-modal-input:focus {
+  outline: none;
+  border-color: #22c55e;
+}
+
+.profile-modal-actions {
+  margin-top: 8px;
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.profile-modal-btn {
+  border: 0;
+  border-radius: 10px;
+  padding: 10px 14px;
+  font-size: 13px;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.profile-modal-btn.ghost {
+  background: #1f2937;
+  color: #e5e7eb;
+}
+
+.profile-modal-btn.primary {
+  background: #22c55e;
+  color: #0a0f14;
+}
+
+.profile-modal-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+@media (max-width: 560px) {
+  .profile-modal-card {
+    padding: 20px;
+  }
+
+  .profile-modal-title {
+    font-size: 20px;
+  }
+}

--- a/frontend/src/components/Profile/ProfileEditModal.js
+++ b/frontend/src/components/Profile/ProfileEditModal.js
@@ -1,0 +1,226 @@
+import React, { useEffect, useMemo, useState } from "react";
+import { useAuth } from "../../contexts/AuthContext";
+import { useToast } from "../../contexts/ToastContext";
+import {
+  canUseProfileUpdateApi,
+  updateMyProfile,
+  uploadProfileImage,
+} from "../../lib/profile";
+import "./ProfileEditModal.css";
+
+const MAX_PROFILE_IMAGE_SIZE = 5 * 1024 * 1024;
+
+function getInitialChar(nickname) {
+  if (!nickname) return "프";
+  return nickname.trim().charAt(0).toUpperCase();
+}
+
+function resolveProfilePayload(result) {
+  if (!result || typeof result !== "object") return null;
+  return result.user || result.profile || result.data || result;
+}
+
+const ProfileEditModal = ({ open, onClose }) => {
+  const { user, updateUser } = useAuth();
+  const toast = useToast();
+  const [nickname, setNickname] = useState("");
+  const [selectedFile, setSelectedFile] = useState(null);
+  const [previewUrl, setPreviewUrl] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const isProfileUpdateEnabled = canUseProfileUpdateApi();
+
+  const displayImageUrl = previewUrl || user?.profileImageUrl || "";
+  const profileInitial = useMemo(
+    () => getInitialChar(nickname || user?.nickname),
+    [nickname, user?.nickname],
+  );
+
+  useEffect(() => {
+    if (!open) return;
+    setNickname(user?.nickname || "");
+    setSelectedFile(null);
+    setPreviewUrl("");
+  }, [open, user?.nickname]);
+
+  useEffect(() => {
+    return () => {
+      if (previewUrl && previewUrl.startsWith("blob:")) {
+        URL.revokeObjectURL(previewUrl);
+      }
+    };
+  }, [previewUrl]);
+
+  if (!open) {
+    return null;
+  }
+
+  const handleOverlayClick = (event) => {
+    if (event.target === event.currentTarget && !isSubmitting) {
+      onClose();
+    }
+  };
+
+  const handleFileChange = (event) => {
+    const file = event.target.files?.[0] || null;
+    if (!file) return;
+
+    if (!file.type.startsWith("image/")) {
+      toast.error("파일 형식 오류", "이미지 파일만 업로드할 수 있습니다.");
+      return;
+    }
+
+    if (file.size > MAX_PROFILE_IMAGE_SIZE) {
+      toast.error("파일 크기 초과", "프로필 이미지는 5MB 이하만 가능합니다.");
+      return;
+    }
+
+    if (previewUrl && previewUrl.startsWith("blob:")) {
+      URL.revokeObjectURL(previewUrl);
+    }
+
+    setSelectedFile(file);
+    setPreviewUrl(URL.createObjectURL(file));
+  };
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+
+    const trimmedNickname = nickname.trim();
+
+    if (!trimmedNickname) {
+      toast.error("입력 확인", "닉네임을 입력해 주세요.");
+      return;
+    }
+    if (!isProfileUpdateEnabled) {
+      toast.error(
+        "API 미설정",
+        "백엔드 프로필 수정 API가 없습니다. 환경변수(REACT_APP_PROFILE_UPDATE_ENDPOINT) 연결 후 다시 시도해 주세요.",
+      );
+      return;
+    }
+
+    setIsSubmitting(true);
+
+    try {
+      let nextProfileImageUrl = user?.profileImageUrl || null;
+
+      if (selectedFile) {
+        const uploadResult = await uploadProfileImage(selectedFile);
+        nextProfileImageUrl =
+          uploadResult?.fileUrl || uploadResult?.profileImageUrl || nextProfileImageUrl;
+      }
+
+      const result = await updateMyProfile({
+        nickname: trimmedNickname,
+        profileImageUrl: nextProfileImageUrl,
+      });
+
+      const profile = resolveProfilePayload(result) || {};
+      const syncedUser = {
+        userId: user?.userId || null,
+        nickname: profile.nickname ?? trimmedNickname,
+        profileImageUrl:
+          profile.profileImageUrl !== undefined
+            ? profile.profileImageUrl
+            : nextProfileImageUrl,
+      };
+
+      updateUser((prev) => ({ ...prev, ...syncedUser }));
+      toast.success("프로필 저장 완료", "내 정보가 업데이트되었습니다.");
+      onClose();
+    } catch (error) {
+      toast.error("프로필 저장 실패", error.message || "잠시 후 다시 시도해 주세요.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="profile-modal-overlay" onClick={handleOverlayClick}>
+      <div
+        className="profile-modal-card"
+        role="dialog"
+        aria-modal="true"
+        aria-label="프로필 수정"
+      >
+        <button
+          type="button"
+          className="profile-modal-close"
+          onClick={onClose}
+          disabled={isSubmitting}
+          aria-label="모달 닫기"
+        >
+          ✕
+        </button>
+
+        <h2 className="profile-modal-title">프로필 수정</h2>
+        <p className="profile-modal-description">
+          닉네임과 프로필 이미지를 변경할 수 있습니다.
+        </p>
+
+        <form className="profile-modal-form" onSubmit={handleSubmit}>
+          <div className="profile-modal-avatar-row">
+            {displayImageUrl ? (
+              <img
+                src={displayImageUrl}
+                alt="프로필 미리보기"
+                className="profile-modal-avatar-image"
+              />
+            ) : (
+              <div className="profile-modal-avatar-fallback">{profileInitial}</div>
+            )}
+
+            <label
+              className="profile-modal-upload-button"
+              htmlFor="profile-image-input"
+            >
+              이미지 선택
+            </label>
+            <input
+              id="profile-image-input"
+              type="file"
+              accept="image/*"
+              onChange={handleFileChange}
+              disabled={isSubmitting}
+            />
+          </div>
+
+          <label className="profile-modal-label" htmlFor="profile-nickname-input">
+            닉네임
+          </label>
+          <input
+            id="profile-nickname-input"
+            className="profile-modal-input"
+            type="text"
+            value={nickname}
+            onChange={(event) => setNickname(event.target.value)}
+            maxLength={20}
+            required
+            disabled={isSubmitting}
+            placeholder="닉네임을 입력하세요"
+          />
+
+          <div className="profile-modal-actions">
+            <button
+              type="button"
+              className="profile-modal-btn ghost"
+              onClick={onClose}
+              disabled={isSubmitting}
+            >
+              취소
+            </button>
+            <button
+              type="submit"
+              className="profile-modal-btn primary"
+              disabled={isSubmitting}
+            >
+              {isSubmitting ? "저장 중..." : "저장"}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default ProfileEditModal;

--- a/frontend/src/components/layout/ServerSidebar.css
+++ b/frontend/src/components/layout/ServerSidebar.css
@@ -113,6 +113,13 @@
   color: #00ff66;
   font-size: 14px;
   font-weight: 700;
+  overflow: hidden;
+}
+
+.profile-icon-image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
 }
  
 /* 설정 팝업 */

--- a/frontend/src/components/layout/ServerSidebar.js
+++ b/frontend/src/components/layout/ServerSidebar.js
@@ -1,9 +1,10 @@
 import React, { useState, useRef, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
-import { getServerPath, PATHS } from "../../constants/path";
+import { getServerPath } from "../../constants/path";
 import { useAuth } from "../../contexts/AuthContext";
 import { useServers } from "../../contexts/ServerContext";
 import { getServerId, getServerName } from "../../lib/serverEntity";
+import ProfileEditModal from "../Profile/ProfileEditModal";
 import "./ServerSidebar.css";
 
 function handleRightClick(event, callback, payload) {
@@ -32,6 +33,7 @@ const ServerSidebar = ({
   const { user } = useAuth();
   const { joinedServers, activeServerId } = useServers();
   const [isProfileMenuOpen, setIsProfileMenuOpen] = useState(false);
+  const [isProfileEditOpen, setIsProfileEditOpen] = useState(false);
   const menuRef = useRef(null);
 
   const initial = user?.nickname ? user.nickname.charAt(0) : "프";
@@ -53,7 +55,7 @@ const ServerSidebar = ({
 
   const handleProfileEdit = () => {
     setIsProfileMenuOpen(false);
-    navigate(PATHS.profileEdit || "/profile/edit");
+    setIsProfileEditOpen(true);
   };
 
   return (
@@ -127,9 +129,22 @@ const ServerSidebar = ({
           onClick={() => setIsProfileMenuOpen((prev) => !prev)}
           title={user?.nickname || "프로필"}
         >
-          {initial}
+          {user?.profileImageUrl ? (
+            <img
+              src={user.profileImageUrl}
+              alt={user?.nickname || "프로필"}
+              className="profile-icon-image"
+            />
+          ) : (
+            initial
+          )}
         </div>
       </div>
+
+      <ProfileEditModal
+        open={isProfileEditOpen}
+        onClose={() => setIsProfileEditOpen(false)}
+      />
     </nav>
   );
 };

--- a/frontend/src/constants/endpoint.js
+++ b/frontend/src/constants/endpoint.js
@@ -13,6 +13,16 @@ export const ENDPOINTS = {
     refresh: "/token/refresh",
     logout: "/userLogout",
   },
+  profile: {
+    me: process.env.REACT_APP_PROFILE_ME_ENDPOINT || "",
+    update: process.env.REACT_APP_PROFILE_UPDATE_ENDPOINT || "",
+    uploadUrl:
+      process.env.REACT_APP_PROFILE_UPLOAD_URL_ENDPOINT ||
+      "",
+  },
+  resources: {
+    uploadUrl: "/resources/upload-url",
+  },
   servers: {
     list: "/servers",
     mine: "/servers/me",

--- a/frontend/src/contexts/AuthContext.js
+++ b/frontend/src/contexts/AuthContext.js
@@ -96,6 +96,32 @@ export const AuthProvider = ({ children }) => {
     localStorage.removeItem(USER_KEY);
   };
 
+  const updateUser = (nextUserOrUpdater) => {
+    setUser((prevUser) => {
+      const nextUser =
+        typeof nextUserOrUpdater === "function"
+          ? nextUserOrUpdater(prevUser)
+          : nextUserOrUpdater;
+
+      if (!nextUser) {
+        localStorage.removeItem(USER_KEY);
+        return null;
+      }
+
+      const resolvedUser = {
+        userId: nextUser.userId ?? prevUser?.userId ?? null,
+        nickname: nextUser.nickname ?? prevUser?.nickname ?? "",
+        profileImageUrl:
+          nextUser.profileImageUrl !== undefined
+            ? nextUser.profileImageUrl
+            : prevUser?.profileImageUrl ?? null,
+      };
+
+      localStorage.setItem(USER_KEY, JSON.stringify(resolvedUser));
+      return resolvedUser;
+    });
+  };
+
   return (
     <AuthContext.Provider
       value={{
@@ -106,6 +132,7 @@ export const AuthProvider = ({ children }) => {
         login,
         logout,
         updateAccessToken,
+        updateUser,
       }}
     >
       {children}

--- a/frontend/src/lib/profile.js
+++ b/frontend/src/lib/profile.js
@@ -1,0 +1,68 @@
+import { ENDPOINTS } from "../constants/endpoint";
+import { request } from "./request";
+
+function hasPath(path) {
+  return typeof path === "string" && path.trim() !== "";
+}
+
+export function canUseProfileReadApi() {
+  return hasPath(ENDPOINTS.profile.me);
+}
+
+export function canUseProfileUpdateApi() {
+  return hasPath(ENDPOINTS.profile.update);
+}
+
+export function getMyProfile() {
+  if (!canUseProfileReadApi()) {
+    return null;
+  }
+
+  return request(ENDPOINTS.profile.me, {
+    method: "GET",
+  });
+}
+
+export function updateMyProfile(payload) {
+  if (!canUseProfileUpdateApi()) {
+    throw new Error(
+      "프로필 수정 API가 설정되지 않았습니다. REACT_APP_PROFILE_UPDATE_ENDPOINT를 확인해 주세요.",
+    );
+  }
+
+  return request(ENDPOINTS.profile.update, {
+    method: "PATCH",
+    body: JSON.stringify(payload),
+  });
+}
+
+export function getProfileImageUploadUrl(fileName, fileType) {
+  const basePath = hasPath(ENDPOINTS.profile.uploadUrl)
+    ? ENDPOINTS.profile.uploadUrl
+    : ENDPOINTS.resources.uploadUrl;
+  const params = new URLSearchParams({ fileName, fileType });
+  return request(`${basePath}?${params.toString()}`, {
+    method: "GET",
+  });
+}
+
+export async function uploadProfileImage(file) {
+  const { uploadUrl, fileUrl, s3ObjectKey } = await getProfileImageUploadUrl(
+    file.name,
+    file.type || "application/octet-stream",
+  );
+
+  const uploadResponse = await fetch(uploadUrl, {
+    method: "PUT",
+    body: file,
+    headers: {
+      "Content-Type": file.type || "application/octet-stream",
+    },
+  });
+
+  if (!uploadResponse.ok) {
+    throw new Error("프로필 이미지 업로드에 실패했습니다.");
+  }
+
+  return { fileUrl, s3ObjectKey };
+}


### PR DESCRIPTION
## 📌 관련 이슈
#(이슈 번호)

## 🏷️ 작업 유형 (Type of Change)
- [x] ✨ 기능 추가 (Feature)
- [x] 🐛 버그 수정 (Fix)
- [x] 🎨 UI/UX 및 디자인 변경 (Design)
- [ ] ♻️ 리팩토링 (Refactor)
- [ ] 📝 문서 작업 (Docs)

## 🚀 작업 내용
- 서버 사이드바 하단 프로필 메뉴에 **프로필 수정 모달**을 연결하고, 닉네임/프로필 이미지 수정 UI를 구현했습니다.
- 프로필 이미지 선택 시 미리보기 및 파일 유효성 검사(이미지 타입, 5MB 제한)를 추가했습니다.
- `AuthContext`에 `updateUser`를 추가해 프로필 변경 후 전역 상태 및 `localStorage` 동기화를 지원했습니다.
- 프로필 아이콘이 텍스트 이니셜 대신 `profileImageUrl`을 우선 표시하도록 변경했습니다.
- 프로필 API 미구현 백엔드 상태를 반영해, 모달 오픈 시 불필요한 `/users/me` 호출을 제거하고 API 미설정 시 사용자 안내 토스트를 표시하도록 보완했습니다.
- 프로필 이미지 업로드 URL은 `REACT_APP_PROFILE_UPLOAD_URL_ENDPOINT` 우선, 미설정 시 `/resources/upload-url` fallback을 사용하도록 구성했습니다.

## ✅ 체크리스트
- [x] `README.md`에 명시된 코딩 컨벤션 및 커밋 메시지 규칙을 준수했습니다.
- [x] 관련 없는 코드나 불필요한 주석을 포함하지 않았습니다.
- [ ] 작업할 브랜치(예: `dev`)의 최신 상태를 pull 받아 충돌이 없는 것을 확인했습니다.
- [ ] (Backend) 람다 함수나 DB 스키마 변경 시 로컬/테스트 환경에서 검증을 완료했습니다.

## 💬 리뷰어에게
- 현재 저장소 기준으로 백엔드에 프로필 전용 API(`GET/PATCH /users/me` 등)는 아직 등록되어 있지 않아, 프론트는 API 경로를 **환경변수 기반으로 연결 가능**하게 처리했습니다.
- 실제 프로필 저장을 활성화하려면 `REACT_APP_PROFILE_UPDATE_ENDPOINT`(필수)와 필요 시 `REACT_APP_PROFILE_UPLOAD_URL_ENDPOINT`를 설정해 주세요.
- 프론트 빌드는 `npm --prefix frontend run build`로 정상 확인했습니다.
